### PR TITLE
fix: prevent LLM from generating dummy access tokens in cost estimator

### DIFF
--- a/03_identity/test_identity_agent.py
+++ b/03_identity/test_identity_agent.py
@@ -81,7 +81,7 @@ async def main():
 
     agent = Agent(
         system_prompt=(
-            "Your are a professional solution architect. "
+            "You are a professional solution architect. "
             "You will receive architecture descriptions or requirements from customers. "
             "Please provide estimate by using 'cost_estimator_tool'"
         ),


### PR DESCRIPTION
- Separate tool definition from auth logic to hide access_token from LLM
- Fix JWT decoding with proper Base64 padding and error handling