### PR TITLE
Fix permissions for agentcore runtime

### DIFF
--- a/02_runtime/prepare_agent.py
+++ b/02_runtime/prepare_agent.py
@@ -243,6 +243,13 @@ class AgentPreparer:
                         "bedrock-agentcore:ListCodeInterpreterSessions"
                     ],
                     "Resource": "arn:aws:bedrock-agentcore:*:*:*"
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "pricing:*"
+                    ],
+                    "Resource": "*"
                 }
             ]
         }
@@ -283,18 +290,6 @@ class AgentPreparer:
                 
             except ClientError as e:
                 logger.error(f"Failed to attach execution policy: {e}")
-                return {}  # Return empty dict to indicate failure
-
-            # Attach additional policy for pricing mcp
-            try:
-                self.iam_client.attach_role_policy(
-                    RoleName=role_name,
-                    PolicyArn='arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess'
-                )
-                logger.info(f"Pricing policy attached to role: {role_name}")
-
-            except ClientError as e:
-                logger.error(f"Failed to attach pricing policy: {e}")
                 return {}  # Return empty dict to indicate failure
 
         return {

--- a/02_runtime/prepare_agent.py
+++ b/02_runtime/prepare_agent.py
@@ -285,6 +285,18 @@ class AgentPreparer:
                 logger.error(f"Failed to attach execution policy: {e}")
                 return {}  # Return empty dict to indicate failure
 
+            # Attach additional policy for pricing mcp
+            try:
+                self.iam_client.attach_role_policy(
+                    RoleName=role_name,
+                    PolicyArn='arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess'
+                )
+                logger.info(f"Pricing policy attached to role: {role_name}")
+
+            except ClientError as e:
+                logger.error(f"Failed to attach pricing policy: {e}")
+                return {}  # Return empty dict to indicate failure
+
         return {
             'agent_name': self.agent_name,
             'role_name': role_name,


### PR DESCRIPTION
Add missing AWSPriceListServiceFullAccess policy to execution role. Pricing MCP functionality in AgentCore Runtime was failing due to missing IAM permissions.

*Issue #, if available:*
N/A

*Description of changes:*
attach additional policy `AWSPriceListServiceFullAccess` to  role `AgentCoreRole-cost_estimator_agent`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
