### PR TITLE
Extend read_timeout

### DIFF
--- a/05_observability/test_observability.py
+++ b/05_observability/test_observability.py
@@ -20,6 +20,7 @@ import yaml
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any
+from botocore.config import Config
 
 # Configure logging
 logging.basicConfig(
@@ -38,7 +39,11 @@ class ObservabilityTester:
         if not self.region:
             # Use default region from boto3 session if not specified
             self.region = boto3.Session().region_name
-        self.client = boto3.client('bedrock-agentcore', region_name=self.region)
+        config = Config(
+            region_name=self.region
+            read_timeout=600 
+        )
+        self.client = boto3.client('bedrock-agentcore', config=config)
     
     def generate_session_id(self, user_id: str) -> str:
         """Generate meaningful session ID with minimum length requirement"""


### PR DESCRIPTION
*Description of changes:*
On lab05 of the workshop, timeout of boto3 occurs frequently as the default timeout is set to 60 seconds.
This PR extends timeout value to 600 seconds.

