### PR TITLE
Migrate Cedar policy to scope-based role matching with NL2Cedar

### DIFF
--- a/08_policy/README.md
+++ b/08_policy/README.md
@@ -76,37 +76,21 @@ When a tool call arrives at the Gateway, AgentCore automatically constructs the 
 >
 > **Reference**: For details on the authorization flow, see [Authorization Flow](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy-authorization-flow.html). For scope element definitions, see [Policy Scope](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy-scope.html). For condition expressions (`when`/`unless` clauses), see [Policy Conditions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy-conditions.html).
 
-#### 4. In This Workshop: M2M Principal Matching
+#### 4. In This Workshop: Scope-Based Role Matching
 
-In this workshop, we use **M2M (Machine-to-Machine) OAuth** via Cognito `client_credentials` flow. We create two separate app clients, one for "Manager" and one for "Developer" and Manager client has permission to send email. In the `client_credentials` flow, each app client has a unique **client ID** that becomes the JWT `sub` claim and thus the Cedar **principal**
+In this workshop, we use **M2M (Machine-to-Machine) OAuth** via Cognito `client_credentials` flow. We create two app clients — "Manager" and "Developer" — and assign them **role-specific scopes** through the existing Cognito resource server:
 
-The Cedar policy uses `principal == AgentCore::OAuthUser::"<manager_client_id>"` to permit only the Manager. Since there is no matching `permit` for the Developer's client ID, the default-deny blocks email access automatically.
+- **Manager client** gets `invoke` + `manager` scopes
+- **Developer client** gets `invoke` + `developer` scopes
 
-This client separation is not necessary if you need ordinal OAuth with JWT token through `Authorization Flow` that contains claims like `username`, `role`, or `scope` that Cedar can evaluate. 
+The Cedar policy uses `principal.getTag("scope") like "*manager*"` to check whether the caller's JWT contains the `manager` scope. Since the Developer's token only carries `invoke developer` (no `manager` scope), the default-deny blocks email access automatically.
 
 | Cedar Element | M2M Value in This Workshop |
 |:---|:---|
-| **principal** | `AgentCore::OAuthUser::"<client_id>"` — the JWT `sub` claim, unique per app client |
+| **principal** | `AgentCore::OAuthUser::"<client_id>"` with scope tags from JWT |
 | **action** | `AgentCore::Action::"AWSCostEstimatorGatewayTarget___markdown_to_email"` |
 | **resource** | `AgentCore::Gateway::"arn:aws:bedrock-agentcore:...:gateway/..."` |
-
-> **In production: Scope-based or role-based matching**
->
-> With user-facing OAuth (Authorization Code flow), Cedar `when` clauses can evaluate JWT claims for more flexible access control:
-> ```cedar
-> // Scope-based: permit anyone with the email-send scope
-> when {
->   principal.hasTag("scope") &&
->   principal.getTag("scope") like "*email-send*"
-> };
->
-> // Role-based: permit only managers
-> when {
->   principal.hasTag("role") &&
->   principal.getTag("role") == "manager"
-> };
-> ```
-> These patterns decouple the policy from specific client IDs and are the recommended approach for production. Cedar `when` clauses can also restrict by user identity (`principal.getTag("username")`), and tool input parameters (`context.input.amount < 500`). For more patterns, see [Common Policy Patterns](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy-common-patterns.html) and [Example Policies](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/example-policies.html). For Cedar operator syntax, see the [Cedar Operators Reference](https://docs.cedarpolicy.com/policies/syntax-operators.html).
+| **when condition** | `principal.getTag("scope") like "*manager*"` — matches the `manager` scope in the JWT |
 
 ## Process Overview
 
@@ -118,16 +102,16 @@ sequenceDiagram
     participant Tool as markdown_to_email
     participant CE as cost_estimator
 
-    M->>GW: Request (Manager's client_id in JWT sub)
-    GW->>GW: Cedar: principal matches Manager → PERMIT
+    M->>GW: Request (Manager's manager scope in JWT)
+    GW->>GW: Cedar: scope matches manager → PERMIT
     Note over GW: Tool list: [cost_estimator, markdown_to_email]
     GW->>CE: Estimate costs
     CE-->>GW: Cost report
     GW->>Tool: Send email
     Tool-->>M: Email sent ✓
 
-    D->>GW: Request (Developer's client_id in JWT sub)
-    GW->>GW: Cedar: no matching permit → default-deny
+    D->>GW: Request (Developer's developer scope in JWT)
+    GW->>GW: Cedar: scope lacks manager → default-deny
     Note over GW: Tool list: [cost_estimator] (email tool hidden)
     GW->>CE: Estimate costs
     CE-->>D: Cost report only (agent never sees email tool)
@@ -167,11 +151,11 @@ uv run python setup_policy.py
 
 This performs the following:
 
-1. **Creates two M2M app clients** (Manager and Developer) with the same `invoke` scope
+1. **Creates two M2M app clients** (Manager and Developer) with **role-specific scopes** (`invoke` + `manager` or `invoke` + `developer`)
 2. **Updates the Gateway's `allowedClients`** so tokens from both new clients are accepted
 3. **Creates a Policy Engine** — the container for Cedar policies
 4. **Demonstrates NL2Cedar** — converts a natural language description into a Cedar policy using `StartPolicyGeneration`
-5. **Creates the Cedar policy** — permits `markdown_to_email` only for the Manager's client ID
+5. **Creates the Cedar policy** — permits `markdown_to_email` only for callers whose JWT scope contains `manager`
 6. **Attaches the Policy Engine** to the Gateway in `ENFORCE` mode
 
 ### Step 2: Test as Developer (email DENIED)
@@ -180,7 +164,7 @@ This performs the following:
 uv run python test_policy.py --role developer --address you@example.com
 ```
 
-The Developer's token carries a different `sub` (client ID) than the Manager's. The Cedar policy has no `permit` matching the Developer's principal, so the **default-deny** kicks in and the `markdown_to_email` tool is **not visible** in the tool list. The agent estimates costs but cannot send the email. Compare the tool list in the log output — `markdown_to_email` is filtered out by policy.
+The Developer's token carries the `developer` scope but not `manager`. The Cedar policy requires the `manager` scope to permit `markdown_to_email`, so the **default-deny** kicks in and the `markdown_to_email` tool is **not visible** in the tool list. The agent estimates costs but cannot send the email. Compare the tool list in the log output — `markdown_to_email` is filtered out by policy.
 
 ### Step 3: Test as Manager (email ALLOWED)
 
@@ -188,7 +172,7 @@ The Developer's token carries a different `sub` (client ID) than the Manager's. 
 uv run python test_policy.py --role manager --address you@example.com
 ```
 
-The Manager's token carries the client ID that the Cedar policy explicitly permits. The policy matches the `principal`, and **allows** the `markdown_to_email` tool call. The agent estimates costs AND sends the email to the client.
+The Manager's token carries the `manager` scope that the Cedar policy checks for. The policy matches the scope via `like "*manager*"`, and **allows** the `markdown_to_email` tool call. The agent estimates costs AND sends the email to the client.
 
 ### Step 4: Clean Up
 
@@ -198,19 +182,22 @@ uv run python clean_resources.py
 
 ## Key Implementation Details
 
-### Cedar Policy: Principal-Based Tool Access
+### Cedar Policy: Scope-Based Tool Access
 
 ```cedar
 permit(
-  principal == AgentCore::OAuthUser::"<manager_client_id>",
+  principal,
   action == AgentCore::Action::"AWSCostEstimatorGatewayTarget___markdown_to_email",
   resource == AgentCore::Gateway::"arn:aws:bedrock-agentcore:...:gateway/..."
-);
+) when {
+  principal.hasTag("scope") &&
+  principal.getTag("scope") like "*manager*"
+};
 ```
 
-This policy reads: "Allow the Manager application (identified by its OAuth client ID) to call the `markdown_to_email` tool on this Gateway."
+This policy reads: "Allow any caller whose JWT scope contains `manager` to call the `markdown_to_email` tool on this Gateway."
 
-The `setup_policy.py` script automatically inserts the Manager's actual client ID into the policy. Since there is no `permit` policy for the Developer's client ID, the default-deny behavior blocks them automatically — the email tool is not even visible in the Developer's tool list.
+The `setup_policy.py` script creates this scope-based policy automatically. Since the Developer's token only carries `invoke developer` scopes (no `manager`), the `when` condition fails and the default-deny behavior blocks them automatically — the email tool is not even visible in the Developer's tool list.
 
 ### NL2Cedar: Generating Policies from Natural Language
 
@@ -219,7 +206,7 @@ One of AgentCore Policy's most powerful features is **NL2Cedar** — the ability
 ```python
 # Describe the policy intent in natural language
 nl_description = (
-    "Allow users who have the email-send scope in their OAuth token "
+    "Allow any user whose OAuth token scope contains 'manager' "
     "to use the markdown_to_email tool on the gateway. "
     "Deny all other users from using the markdown_to_email tool."
 )
@@ -227,21 +214,30 @@ nl_description = (
 # Generate Cedar policy
 generation = policy_client.generate_policy(
     policy_engine_id=engine_id,
-    name="demo_nl2cedar_generation",
+    name="scope_based_email_policy",
     resource={"arn": gateway_arn},
     content={"rawText": nl_description},
     fetch_assets=True,
 )
 
-# Review the generated Cedar statement
+# Review the generated Cedar statements
 for asset in generation["generatedPolicies"]:
     print(asset["definition"]["cedar"]["statement"])
 ```
 
-The `setup_policy.py` script runs this as an informational demo so you can see the generated Cedar. In practice, you would:
-1. Generate candidate policies from natural language
-2. Review and optionally adjust the generated Cedar
-3. Create the final policy using `CreatePolicy`
+NL2Cedar generates a **pair of complementary policies** — a `permit` and a `forbid` — that together express the intent:
+
+```cedar
+// Policy 1: Allow callers with the manager scope
+permit(principal, action == ..., resource == ...)
+when { principal.hasTag("scope") && principal.getTag("scope") like "*manager*" };
+
+// Policy 2: Explicitly deny callers without the manager scope
+forbid(principal, action == ..., resource == ...)
+when { !(principal.hasTag("scope") && principal.getTag("scope") like "*manager*") };
+```
+
+In a default-deny system like AgentCore, the `forbid` policy is redundant — callers without a matching `permit` are already blocked. However, NL2Cedar generates both to be explicit. The `setup_policy.py` script uses the generated `permit` policy as the actual Cedar policy, with a hand-crafted fallback if NL2Cedar is unavailable.
 
 > **Tip**: For best NL2Cedar results, be specific about WHO (principal), WHAT (tool/action), and WHEN (conditions). Vague descriptions like "allow access" produce overly broad policies.
 

--- a/08_policy/README_ja.md
+++ b/08_policy/README_ja.md
@@ -78,37 +78,21 @@ Gatewayがツール呼び出しを受信すると、AgentCoreは以下の2つの
 >
 > **参考**: 認可フローの詳細は[Authorization Flow](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy-authorization-flow.html)を参照。スコープ要素の定義は[Policy Scope](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy-scope.html)を参照。条件式（`when`/`unless`句）は[Policy Conditions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy-conditions.html)を参照。
 
-#### 4. このワークショップ: M2Mプリンシパルマッチング
+#### 4. このワークショップ: スコープベースのロールマッチング
 
-このワークショップでは、Cognitoの `client_credentials` フローによる **M2M（Machine-to-Machine）OAuth** を使用します。「Manager」用と「Developer」用の2つのアプリクライアントを作成し、CedarポリシーでManagerにのみメール送信を許可します。`client_credentials` フローでは、各アプリクライアントが一意の **クライアントID** を持ち、これがJWTの `sub` クレームとしてCedarの **principal** になります。
+このワークショップでは、Cognitoの `client_credentials` フローによる **M2M（Machine-to-Machine）OAuth** を使用します。「Manager」用と「Developer」用の2つのアプリクライアントを作成し、既存のCognitoリソースサーバーに **ロール固有のスコープ** を追加します：
 
-Cedarポリシーで `principal == AgentCore::OAuthUser::"<manager_client_id>"` と指定し、Managerのみにメールツールの使用を許可します。DeveloperのクライアントIDに一致する `permit` がないため、デフォルト拒否により自動的にブロックされます。
+- **Managerクライアント** — `invoke` + `manager` スコープ
+- **Developerクライアント** — `invoke` + `developer` スコープ
 
-Authorization Codeフローで `username`、`role`、`scope` などのクレームを含むJWTを利用する場合、このようなクライアント分離は不要です。
+Cedarポリシーでは `principal.getTag("scope") like "*manager*"` を使い、JWTに `manager` スコープが含まれているかを判定します。Developerのトークンには `invoke developer` しか含まれず `manager` スコープがないため、デフォルト拒否によりメール送信は自動的にブロックされます。
 
 | Cedar要素 | このワークショップでのM2M値 |
 |:---|:---|
-| **principal** | `AgentCore::OAuthUser::"<client_id>"` — JWT `sub` クレーム、アプリクライアントごとに一意 |
+| **principal** | `AgentCore::OAuthUser::"<client_id>"` — JWTのスコープタグ付き |
 | **action** | `AgentCore::Action::"AWSCostEstimatorGatewayTarget___markdown_to_email"` |
 | **resource** | `AgentCore::Gateway::"arn:aws:bedrock-agentcore:...:gateway/..."` |
-
-> **本番環境: スコープベースまたはロールベースのマッチング**
->
-> ユーザー向けOAuth（Authorization Codeフロー）では、Cedar `when` 句でJWTクレームを評価し、より柔軟なアクセス制御が可能です：
-> ```cedar
-> // スコープベース: email-sendスコープを持つすべてのユーザーを許可
-> when {
->   principal.hasTag("scope") &&
->   principal.getTag("scope") like "*email-send*"
-> };
->
-> // ロールベース: マネージャーのみ許可
-> when {
->   principal.hasTag("role") &&
->   principal.getTag("role") == "manager"
-> };
-> ```
-> これらのパターンはポリシーを特定のクライアントIDに依存させず、本番環境で推奨されるアプローチです。Cedar `when` 句では、ユーザーID（`principal.getTag("username")`）やツール入力パラメータ（`context.input.amount < 500`）による制限も可能です。詳細は[一般的なポリシーパターン](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy-common-patterns.html)と[ポリシー例](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/example-policies.html)を参照してください。Cedarの演算子構文については[Cedar Operators Reference](https://docs.cedarpolicy.com/policies/syntax-operators.html)を参照してください。
+| **when条件** | `principal.getTag("scope") like "*manager*"` — JWT内の `manager` スコープに一致 |
 
 ## プロセス概要
 
@@ -120,16 +104,16 @@ sequenceDiagram
     participant Tool as markdown_to_email
     participant CE as cost_estimator
 
-    M->>GW: リクエスト（ManagerのクライアントIDがJWT subに含まれる）
-    GW->>GW: Cedar: principalがManagerに一致 → 許可
+    M->>GW: リクエスト（Managerのmanagerスコープがトークンに含まれる）
+    GW->>GW: Cedar: scopeにmanagerを含む → 許可
     Note over GW: ツール一覧: [cost_estimator, markdown_to_email]
     GW->>CE: コスト見積もり
     CE-->>GW: コストレポート
     GW->>Tool: メール送信
     Tool-->>M: メール送信完了 ✓
 
-    D->>GW: リクエスト（DeveloperのクライアントIDがJWT subに含まれる）
-    GW->>GW: Cedar: 一致するpermitなし → デフォルト拒否
+    D->>GW: リクエスト（DeveloperのdeveloperスコープがJWTに含まれる）
+    GW->>GW: Cedar: scopeにmanagerを含まない → デフォルト拒否
     Note over GW: ツール一覧: [cost_estimator]（メールツール非表示）
     GW->>CE: コスト見積もり
     CE-->>D: コストレポートのみ（エージェントはメールツールを認識しない）
@@ -169,11 +153,11 @@ uv run python setup_policy.py
 
 以下を実行します：
 
-1. **2つのM2Mアプリクライアントを作成** — ManagerとDeveloper、同じ `invoke` スコープ
+1. **2つのM2Mアプリクライアントを作成** — ManagerとDeveloper、ロール固有のスコープ付き
 2. **Gatewayの`allowedClients`を更新** — 両方の新クライアントのトークンを受け入れるように
 3. **Policy Engineを作成** — Cedarポリシーのコンテナ
 4. **NL2Cedarのデモ** — `StartPolicyGeneration` を使用して自然言語からCedarポリシーを生成
-5. **Cedarポリシーを作成** — `markdown_to_email` をManagerのクライアントIDにのみ許可
+5. **Cedarポリシーを作成** — スコープマッチングで `markdown_to_email` をManagerにのみ許可
 6. **Policy EngineをGatewayにアタッチ** — `ENFORCE` モードで
 
 ### ステップ2: Developerとしてテスト（メール拒否）
@@ -182,7 +166,7 @@ uv run python setup_policy.py
 uv run python test_policy.py --role developer --address you@example.com
 ```
 
-DeveloperのトークンにはManagerとは異なる `sub`（クライアントID）が含まれています。CedarポリシーにはDeveloperのprincipalに一致する `permit` がないため、**デフォルト拒否** により `markdown_to_email` ツールはツール一覧に **表示されません**。エージェントはコスト見積もりを実行しますが、メールは送信できません。ログ出力のツール一覧を比較すると、`markdown_to_email` がポリシーにより除外されていることを確認できます。
+Developerのトークンには `invoke developer` スコープのみが含まれ、`manager` スコープがありません。Cedarポリシーのスコープマッチング条件を満たさないため、**デフォルト拒否** により `markdown_to_email` ツールはツール一覧に **表示されません**。エージェントはコスト見積もりを実行しますが、メールは送信できません。ログ出力のツール一覧を比較すると、`markdown_to_email` がポリシーにより除外されていることを確認できます。
 
 ### ステップ3: Managerとしてテスト（メール許可）
 
@@ -190,7 +174,7 @@ DeveloperのトークンにはManagerとは異なる `sub`（クライアントI
 uv run python test_policy.py --role manager --address you@example.com
 ```
 
-ManagerのトークンにはCedarポリシーで明示的に許可されたクライアントIDが含まれています。ポリシーが `principal` に一致するため、`markdown_to_email` ツールの呼び出しが **許可** されます。エージェントはコスト見積もりを実行し、結果をメールで送信します。
+Managerのトークンには `invoke manager` スコープが含まれています。Cedarポリシーのスコープマッチング条件に一致するため、`markdown_to_email` ツールの呼び出しが **許可** されます。エージェントはコスト見積もりを実行し、結果をメールで送信します。
 
 ### ステップ4: クリーンアップ
 
@@ -200,19 +184,22 @@ uv run python clean_resources.py
 
 ## 主要な実装の詳細
 
-### Cedarポリシー: プリンシパルベースのツールアクセス
+### Cedarポリシー: スコープベースのツールアクセス
 
 ```cedar
 permit(
-  principal == AgentCore::OAuthUser::"<manager_client_id>",
+  principal,
   action == AgentCore::Action::"AWSCostEstimatorGatewayTarget___markdown_to_email",
   resource == AgentCore::Gateway::"arn:aws:bedrock-agentcore:...:gateway/..."
-);
+) when {
+  principal.hasTag("scope") &&
+  principal.getTag("scope") like "*manager*"
+};
 ```
 
-このポリシーは「Managerアプリケーション（OAuthクライアントIDで識別）に、このGateway上の `markdown_to_email` ツールの呼び出しを許可する」という意味です。
+このポリシーは「JWTに `manager` スコープを持つ呼び出し元に、このGateway上の `markdown_to_email` ツールの呼び出しを許可する」という意味です。
 
-`setup_policy.py` がManagerの実際のクライアントIDをポリシーに自動挿入します。DeveloperのクライアントIDに対する `permit` ポリシーがないため、デフォルト拒否により自動的にブロックされ、メールツールはDeveloperのツール一覧に表示されません。
+`setup_policy.py` がGateway ARNをポリシーに自動挿入します。Developerのトークンには `manager` スコープが含まれないため、`when` 条件を満たさずデフォルト拒否が適用され、メールツールはDeveloperのツール一覧に表示されません。
 
 ### NL2Cedar: 自然言語からポリシー生成
 
@@ -221,7 +208,7 @@ AgentCore Policyの強力な機能の一つが **NL2Cedar** です。`StartPolic
 ```python
 # ポリシーの意図を自然言語で記述
 nl_description = (
-    "Allow users who have the email-send scope in their OAuth token "
+    "Allow any user whose OAuth token scope contains 'manager' "
     "to use the markdown_to_email tool on the gateway. "
     "Deny all other users from using the markdown_to_email tool."
 )
@@ -229,7 +216,7 @@ nl_description = (
 # Cedarポリシーを生成
 generation = policy_client.generate_policy(
     policy_engine_id=engine_id,
-    name="demo_nl2cedar_generation",
+    name="scope_based_email_policy",
     resource={"arn": gateway_arn},
     content={"rawText": nl_description},
     fetch_assets=True,
@@ -240,10 +227,19 @@ for asset in generation["generatedPolicies"]:
     print(asset["definition"]["cedar"]["statement"])
 ```
 
-`setup_policy.py` ではこのNL2Cedar生成をデモとして実行するため、生成されたCedarを確認できます。実際の運用では：
-1. 自然言語から候補ポリシーを生成
-2. 生成されたCedarをレビューし、必要に応じて調整
-3. `CreatePolicy` で最終ポリシーを作成
+NL2Cedarは意図を表現する **相補的な2つのポリシー**（`permit` と `forbid` のペア）を生成します：
+
+```cedar
+// ポリシー1: managerスコープを持つ呼び出し元を許可
+permit(principal, action == ..., resource == ...)
+when { principal.hasTag("scope") && principal.getTag("scope") like "*manager*" };
+
+// ポリシー2: managerスコープを持たない呼び出し元を明示的に拒否
+forbid(principal, action == ..., resource == ...)
+when { !(principal.hasTag("scope") && principal.getTag("scope") like "*manager*") };
+```
+
+AgentCoreのようなデフォルト拒否システムでは、`forbid` ポリシーは冗長です。`permit` に一致しない呼び出し元はそもそもブロックされるためです。ただしNL2Cedarは意図を明示するために両方を生成します。`setup_policy.py` では生成された `permit` ポリシーを実際のCedarポリシーとして使用し、NL2Cedarが利用できない場合は手書きのフォールバックに切り替えます。
 
 > **ヒント**: NL2Cedarで良い結果を得るには、WHO（プリンシパル）、WHAT（ツール/アクション）、WHEN（条件）を具体的に記述してください。「アクセスを許可する」のような曖昧な記述は、過度に広いポリシーを生成します。
 

--- a/08_policy/clean_resources.py
+++ b/08_policy/clean_resources.py
@@ -142,6 +142,23 @@ def clean_resources():
                 except Exception as e:
                     print(f"Warning: Failed to delete {role} client: {e}")
 
+        # Step 4b: Restore resource server to original scopes (invoke only)
+        resource_server_id = cognito_clients.get("resource_server_id")
+        if resource_server_id:
+            print(f"Restoring resource server {resource_server_id} to original scopes...")
+            try:
+                cognito.update_resource_server(
+                    UserPoolId=user_pool_id,
+                    Identifier=resource_server_id,
+                    Name=resource_server_id,
+                    Scopes=[
+                        {"ScopeName": "invoke", "ScopeDescription": "Invoke the agent"},
+                    ],
+                )
+                print("Resource server scopes restored")
+            except Exception as e:
+                print(f"Warning: Failed to restore resource server scopes: {e}")
+
     # Step 5: Remove config file
     print("Removing policy_config.json")
     os.remove(POLICY_CONFIG_FILE)

--- a/08_policy/setup_policy.py
+++ b/08_policy/setup_policy.py
@@ -2,9 +2,10 @@
 Setup Cedar-based policy for fine-grained tool access control on AgentCore Gateway.
 
 This script creates:
-1. Two M2M app clients (Manager and Developer) with the same invoke scope
-2. Policy Engine with Cedar policy permitting email tool only for the Manager's principal
-3. Attaches the policy engine to the existing gateway
+1. Role scopes (manager, developer) on the Cognito resource server
+2. Two M2M app clients with role-specific scopes
+3. Policy Engine with Cedar policy permitting email tool only for the manager scope
+4. Attaches the policy engine to the existing gateway
 
 Prerequisites:
 - 06_identity setup complete (inbound_authorizer.json exists)
@@ -37,7 +38,7 @@ GATEWAY_FILE = Path("../07_gateway/outbound_gateway.json")
 CONFIG_FILE = Path("policy_config.json")
 
 POLICY_ENGINE_NAME = "cost_estimator_policy_engine"
-POLICY_NAME = "email_principal_policy"
+POLICY_NAME = "email_scope_policy"
 
 
 def load_config() -> dict:
@@ -81,12 +82,11 @@ def load_prerequisite_configs() -> tuple[dict, dict]:
 def setup_cognito_clients(
     identity_config: dict, gateway_config: dict, force: bool = False
 ) -> dict:
-    """Create two M2M app clients with the same invoke scope.
+    """Add role scopes to the resource server and create two M2M app clients.
 
-    Both clients get identical scopes. The Cedar policy distinguishes them
-    by principal (client ID), not by scope.
-    - Manager: permitted by Cedar policy to use markdown_to_email
-    - Developer: no matching permit, so email tool is hidden by default-deny
+    Each client gets the invoke scope plus a role scope (manager or developer).
+    The Cedar policy uses scope-based matching to permit the email tool only
+    for tokens that contain the manager scope.
     """
     config = load_config()
     if "cognito_clients" in config and not force:
@@ -98,6 +98,8 @@ def setup_cognito_clients(
     original_client_id = identity_config["cognito"]["client_id"]
     # The existing scope from step 06 (used for gateway invoke)
     existing_scope = identity_config["cognito"]["scope"]
+    # Extract resource server identifier from scope (format: "ResourceServer/scope")
+    resource_server_id = existing_scope.split("/")[0]
 
     cognito = boto3.client("cognito-idp")
 
@@ -106,31 +108,48 @@ def setup_cognito_clients(
         logger.info("Cleaning up existing Cognito resources...")
         _cleanup_cognito_clients(cognito, config["cognito_clients"])
 
-    # Both clients get the same invoke scope.
-    # Access control is handled by Cedar principal matching, not scopes.
-    client_scopes = [existing_scope]
+    # Step 1: Add role scopes to the existing resource server
+    # The resource server was created by step 06 with only the "invoke" scope.
+    # We add "manager" and "developer" scopes for role-based access control.
+    logger.info("Adding role scopes to resource server %s...", resource_server_id)
+    cognito.update_resource_server(
+        UserPoolId=user_pool_id,
+        Identifier=resource_server_id,
+        Name=resource_server_id,
+        Scopes=[
+            {"ScopeName": "invoke", "ScopeDescription": "Invoke the agent"},
+            {"ScopeName": "manager", "ScopeDescription": "Manager role scope"},
+            {"ScopeName": "developer", "ScopeDescription": "Developer role scope"},
+        ],
+    )
+    logger.info("Resource server updated with role scopes")
 
-    # Step 1: Create Manager app client
+    # Manager gets invoke + manager scopes
+    manager_scopes = [existing_scope, f"{resource_server_id}/manager"]
+    # Developer gets invoke + developer scopes
+    developer_scopes = [existing_scope, f"{resource_server_id}/developer"]
+
+    # Step 2: Create Manager app client
     logger.info("Creating Manager app client...")
     manager_response = cognito.create_user_pool_client(
         UserPoolId=user_pool_id,
         ClientName="CostEstimatorManager",
         GenerateSecret=True,
         AllowedOAuthFlows=["client_credentials"],
-        AllowedOAuthScopes=client_scopes,
+        AllowedOAuthScopes=manager_scopes,
         AllowedOAuthFlowsUserPoolClient=True,
     )
     manager_client = manager_response["UserPoolClient"]
     logger.info("Manager client created: %s", manager_client["ClientId"])
 
-    # Step 2: Create Developer app client
+    # Step 3: Create Developer app client
     logger.info("Creating Developer app client...")
     developer_response = cognito.create_user_pool_client(
         UserPoolId=user_pool_id,
         ClientName="CostEstimatorDeveloper",
         GenerateSecret=True,
         AllowedOAuthFlows=["client_credentials"],
-        AllowedOAuthScopes=client_scopes,
+        AllowedOAuthScopes=developer_scopes,
         AllowedOAuthFlowsUserPoolClient=True,
     )
     developer_client = developer_response["UserPoolClient"]
@@ -141,15 +160,16 @@ def setup_cognito_clients(
         "token_endpoint": token_endpoint,
         "original_client_id": original_client_id,
         "existing_scope": existing_scope,
+        "resource_server_id": resource_server_id,
         "manager": {
             "client_id": manager_client["ClientId"],
             "client_secret": manager_client["ClientSecret"],
-            "scopes": " ".join(client_scopes),
+            "scopes": " ".join(manager_scopes),
         },
         "developer": {
             "client_id": developer_client["ClientId"],
             "client_secret": developer_client["ClientSecret"],
-            "scopes": " ".join(client_scopes),
+            "scopes": " ".join(developer_scopes),
         },
     }
     save_config({"cognito_clients": cognito_config})
@@ -223,6 +243,27 @@ def update_gateway_allowed_clients(
     return gateway_arn
 
 
+def _fetch_existing_generation(
+    policy_client: PolicyClient, engine_id: str, gen_name: str
+) -> list:
+    """Fetch assets from an existing NL2Cedar generation by name."""
+    try:
+        generations = policy_client.list_policy_generations(
+            policy_engine_id=engine_id
+        )
+        for gen in generations.get("policyGenerations", []):
+            if gen.get("name", "").startswith(gen_name):
+                gen_id = gen["policyGenerationId"]
+                assets = policy_client.list_policy_generation_assets(
+                    policy_engine_id=engine_id,
+                    policy_generation_id=gen_id,
+                )
+                return assets.get("generatedPolicies", [])
+    except Exception as e:
+        logger.warning("Failed to fetch existing generation: %s", e)
+    return []
+
+
 def setup_policy_engine(console: Console) -> dict:
     """Create policy engine, demo NL2Cedar, and create Cedar policy."""
     config = load_config()
@@ -251,36 +292,62 @@ def setup_policy_engine(console: Console) -> dict:
         engine_id = config["policy_engine"]["id"]
         engine_arn = config["policy_engine"]["arn"]
 
-    # Step 2: Demo NL2Cedar generation (informational only)
-    logger.info("Demonstrating NL2Cedar policy generation...")
+    # Step 2: Generate Cedar policy via NL2Cedar
+    # NL2Cedar converts a natural language description into Cedar policies.
+    # We use the generated policy as the actual policy if it looks valid,
+    # otherwise fall back to a hand-crafted policy.
+    nl2cedar_statement = None
+    nl_description = (
+        "Allow any user whose OAuth token scope contains 'manager' "
+        "to use the markdown_to_email tool on the gateway. "
+        "Deny all other users from using the markdown_to_email tool."
+    )
+    # Derive generation name from engine ID for deterministic naming:
+    # same engine → same name (idempotent), new engine → new name (no stale conflicts)
+    engine_suffix = engine_id.rsplit("-", 1)[-1]
+    gen_name = f"email_scope_nl2cedar_{engine_suffix}"
+    logger.info("Generating Cedar policy via NL2Cedar...")
     try:
-        nl_description = (
-            "Allow users who have the email-send scope in their OAuth token "
-            "to use the markdown_to_email tool on the gateway. "
-            "Deny all other users from using the markdown_to_email tool."
-        )
         generation = policy_client.generate_policy(
             policy_engine_id=engine_id,
-            name="demo_nl2cedar_generation",
+            name=gen_name,
             resource={"arn": gateway_arn},
             content={"rawText": nl_description},
             fetch_assets=True,
         )
+        generated_policies = generation.get("generatedPolicies", [])
+    except Exception as e:
+        # If generation already exists (ConflictException on re-run),
+        # fetch its results instead of failing
+        generated_policies = []
+        if "ConflictException" in str(e):
+            logger.info("NL2Cedar generation already exists, fetching results...")
+            generated_policies = _fetch_existing_generation(
+                policy_client, engine_id, gen_name
+            )
+        else:
+            logger.warning("NL2Cedar generation failed: %s", e)
+
+    if generated_policies:
         console.print(Panel(
             f"[bold]Input:[/bold] {nl_description}",
             title="NL2Cedar: Natural Language Input",
         ))
-        generated_policies = generation.get("generatedPolicies", [])
         for i, asset in enumerate(generated_policies):
             cedar_def = asset.get("definition", {}).get("cedar", {})
-            statement = cedar_def.get("statement", "No statement generated")
-            console.print(Panel(
-                Syntax(statement, "cedar", theme="monokai"),
-                title=f"NL2Cedar: Generated Policy {i + 1}",
-            ))
-        logger.info("NL2Cedar demo complete (for reference only)")
-    except Exception as e:
-        logger.warning("NL2Cedar demo failed (non-critical): %s", e)
+            statement = cedar_def.get("statement", "")
+            if statement:
+                console.print(Panel(
+                    Syntax(statement, "cedar", theme="monokai"),
+                    title=f"NL2Cedar: Generated Policy {i + 1}",
+                ))
+                # Use the first generated policy that contains a permit statement
+                if nl2cedar_statement is None and "permit" in statement:
+                    nl2cedar_statement = statement
+        if nl2cedar_statement:
+            logger.info("NL2Cedar generated a usable policy")
+        else:
+            logger.warning("NL2Cedar output did not contain a usable permit statement")
 
     # Step 3: Create the actual Cedar policy
     if "policy" not in config:
@@ -290,32 +357,38 @@ def setup_policy_engine(console: Console) -> dict:
         tool_name = "markdown_to_email"
         action_name = f"{target_name}___{tool_name}"
 
-        # Use principal identity matching (JWT sub claim = Cognito client_id for M2M)
-        # This permits the email tool ONLY for the Manager's client_id
-        cognito_config = load_config().get("cognito_clients", {})
-        manager_client_id = cognito_config["manager"]["client_id"]
-
-        cedar_statement = (
+        # Hand-crafted fallback policy: scope-based matching with like operator
+        handcrafted_statement = (
             "permit(\n"
-            f'  principal == AgentCore::OAuthUser::"{manager_client_id}",\n'
+            "  principal,\n"
             f'  action == AgentCore::Action::"{action_name}",\n'
             f'  resource == AgentCore::Gateway::"{gateway_arn}"\n'
-            ");"
+            ") when {\n"
+            '  principal.hasTag("scope") &&\n'
+            '  principal.getTag("scope") like "*manager*"\n'
+            "};"
         )
+
+        if nl2cedar_statement:
+            cedar_statement = nl2cedar_statement
+            policy_source = "NL2Cedar"
+        else:
+            cedar_statement = handcrafted_statement
+            policy_source = "hand-crafted"
 
         console.print(Panel(
             Syntax(cedar_statement, "cedar", theme="monokai"),
-            title="Cedar Policy to Create",
+            title=f"Cedar Policy to Create ({policy_source})",
         ))
 
-        logger.info("Creating Cedar policy...")
+        logger.info("Creating Cedar policy (%s)...", policy_source)
         policy = policy_client.create_or_get_policy(
             policy_engine_id=engine_id,
             name=POLICY_NAME,
             definition={"cedar": {"statement": cedar_statement}},
             description=(
-                "Permit markdown_to_email tool only for the Manager "
-                "OAuth client (identified by JWT sub claim)"
+                "Permit markdown_to_email tool only for OAuth clients "
+                "whose token contains the manager scope"
             ),
         )
         policy_id = policy["policyId"]
@@ -325,9 +398,10 @@ def setup_policy_engine(console: Console) -> dict:
                 "id": policy_id,
                 "arn": policy_arn,
                 "cedar_statement": cedar_statement,
+                "source": policy_source,
             },
         })
-        logger.info("Cedar policy created: %s", policy_id)
+        logger.info("Cedar policy created (%s): %s", policy_source, policy_id)
 
     return load_config()
 
@@ -391,7 +465,7 @@ def main():
         identity_config, gateway_config = load_prerequisite_configs()
         logger.info("Loaded prerequisite configs from step 06 and 07")
 
-        # Step 1: Create Cognito resource server + M2M clients
+        # Step 1: Add role scopes + create M2M clients
         cognito_config = setup_cognito_clients(
             identity_config, gateway_config, force=args.force
         )

--- a/08_policy/test_policy.py
+++ b/08_policy/test_policy.py
@@ -1,9 +1,9 @@
 """
 Test Cedar-based policy enforcement on AgentCore Gateway.
 
-Demonstrates principal-based access control:
-- Manager: principal matches Cedar permit -> can estimate costs AND send emails
-- Developer: no matching permit -> email tool is hidden by policy (default-deny)
+Demonstrates scope-based access control:
+- Manager: token contains manager scope -> Cedar permit matches -> can send emails
+- Developer: token lacks manager scope -> no matching permit -> email tool hidden
 
 Usage:
     uv run python 08_policy/test_policy.py --role manager --address you@example.com
@@ -143,9 +143,9 @@ def run_agent_with_role(role: str, architecture: str, address: str, console: Con
             )
 
         if has_email:
-            verdict = "[green bold]PERMITTED[/green bold] — Cedar policy matches this principal"
+            verdict = "[green bold]PERMITTED[/green bold] — token scope matches Cedar policy"
         else:
-            verdict = "[yellow bold]DEFAULT-DENY[/yellow bold] — no matching permit for this principal"
+            verdict = "[yellow bold]DEFAULT-DENY[/yellow bold] — token scope does not match any permit"
 
         console.print(Panel(
             f"[bold]Tools visible to {role.upper()}:[/bold]\n"


### PR DESCRIPTION
## Summary
- Replace hardcoded principal-based Cedar policy (`principal == AgentCore::OAuthUser::"<client_id>"`) with scope-based matching (`principal.getTag("scope") like "*manager*"`) — the recommended production pattern
- Use NL2Cedar-generated policy as the primary Cedar policy source, with hand-crafted fallback if NL2Cedar is unavailable
- Add `manager`/`developer` role scopes to Cognito resource server in setup, restore on cleanup
- Update documentation (EN/JA) with scope-based examples and NL2Cedar two-policy generation explanation

## Test plan
- [x] `cd 08_policy && uv run python clean_resources.py` — clean existing resources
- [x] `uv run python setup_policy.py` — verify NL2Cedar generation + scope-based Cedar policy creation
- [x] `uv run python test_policy.py --role developer --address <email>` — email tool hidden (DEFAULT-DENY)
- [x] `uv run python test_policy.py --role manager --address <email>` — email sent (PERMITTED)
- [x] `uv run python clean_resources.py` — verify cleanup restores resource server scopes
- [x] `ruff check 08_policy/` — lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)