### PR TITLE
Add --disable-memory to Lab 02 configure

### DIFF
--- a/02_runtime/README.md
+++ b/02_runtime/README.md
@@ -62,7 +62,7 @@ The tool provides ready-to-use `agentcore` commands:
 
 ```bash
 # Configure the agent runtime (account id depends on your environment, please confirm outputs of prepare_agent.py)
-uv run agentcore configure --entrypoint ./deployment/invoke.py --name cost_estimator_agent --execution-role arn:aws:iam::123456789012:role/AgentCoreRole-cost_estimator_agent --requirements-file ./deployment/requirements.txt --region us-east-1
+uv run agentcore configure --entrypoint ./deployment/invoke.py --name cost_estimator_agent --execution-role arn:aws:iam::123456789012:role/AgentCoreRole-cost_estimator_agent --requirements-file ./deployment/requirements.txt --disable-memory --region us-east-1
 
 # Deploy the agent (pass AWS_REGION so the runtime can resolve region)
 uv run agentcore deploy --env AWS_REGION=$(aws configure get region)

--- a/02_runtime/README_ja.md
+++ b/02_runtime/README_ja.md
@@ -62,7 +62,7 @@ uv run prepare_agent.py --source-dir ../01_code_interpreter/cost_estimator_agent
 
 ```bash
 # エージェントランタイムを設定 (アカウント id は実行環境に依存します。 `prepare_agent.py` の実行結果を確認してください)
-uv run agentcore configure --entrypoint ./deployment/invoke.py --name cost_estimator_agent --execution-role arn:aws:iam::123456789012:role/AgentCoreRole-cost_estimator_agent --requirements-file ./deployment/requirements.txt --region us-east-1
+uv run agentcore configure --entrypoint ./deployment/invoke.py --name cost_estimator_agent --execution-role arn:aws:iam::123456789012:role/AgentCoreRole-cost_estimator_agent --requirements-file ./deployment/requirements.txt --disable-memory --region us-east-1
 
 # エージェントをデプロイ（Runtime がリージョンを解決できるよう AWS_REGION を渡す）
 uv run agentcore deploy --env AWS_REGION=$(aws configure get region)

--- a/02_runtime/prepare_agent.py
+++ b/02_runtime/prepare_agent.py
@@ -80,6 +80,7 @@ class AgentPreparer:
             f"--requirements-file {deployment_dir}/requirements.txt \\",
             "--non-interactive \\",
             "--deployment-type direct_code_deploy \\",
+            "--disable-memory \\",
             f"--region {self.region} "
         ])
 


### PR DESCRIPTION
## Summary
- Add `--disable-memory` flag to `agentcore configure` in Lab 02 (`prepare_agent.py`, `README.md`, `README_ja.md`)
- Memory is not used until Lab 03, so creating it during Lab 02 deploy wastes ~3 minutes and confuses attendees who haven't learned about memory yet

## Test plan
- [x] Run Lab 02 with `--disable-memory` and verify deploy completes without memory creation
- [x] Run Lab 03 and verify memory is created properly when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)