### PR TITLE
Update model from Claude Sonnet 4 to Sonnet 4.6

### DIFF
--- a/01_code_interpreter/cost_estimator_agent/config.py
+++ b/01_code_interpreter/cost_estimator_agent/config.py
@@ -55,7 +55,7 @@ Please analyze this architecture and provide an AWS cost estimate:
 """
 
 # Model configuration
-DEFAULT_MODEL = "us.anthropic.claude-sonnet-4-20250514-v1:0" 
+DEFAULT_MODEL = "us.anthropic.claude-sonnet-4-6" 
 
 # AWS regions
 DEFAULT_PROFILE = "default"

--- a/03_memory/test_memory.py
+++ b/03_memory/test_memory.py
@@ -397,8 +397,8 @@ class AgentWithMemory:
             Generated content from Bedrock
         """
         try:
-            # Use Claude Sonnet 4 for fast, cost-effective generation
-            model_id = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+            # Use Claude Sonnet 4.6 for fast, cost-effective generation
+            model_id = "us.anthropic.claude-sonnet-4-6"
             
             # Prepare the message
             messages = [

--- a/05_evaluation/test_evaluation.py
+++ b/05_evaluation/test_evaluation.py
@@ -105,7 +105,7 @@ TOOL_USAGE_EVALUATOR_CONFIG = {
     "llmAsAJudge": {
         "modelConfig": {
             "bedrockEvaluatorModelConfig": {
-                "modelId": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+                "modelId": "us.anthropic.claude-sonnet-4-6",
             }
         },
         "instructions": (

--- a/09_browser_use/test_browser_use.py
+++ b/09_browser_use/test_browser_use.py
@@ -75,7 +75,7 @@ def generate_form_values(
     Converse API, which returns a JSON mapping of field names to values.
     """
     bedrock_runtime = boto3.client("bedrock-runtime", region_name=region)
-    model_id = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+    model_id = "us.anthropic.claude-sonnet-4-6"
 
     extra_context = ""
     if signature:

--- a/a1_custom/.kiro/steering/principle.md
+++ b/a1_custom/.kiro/steering/principle.md
@@ -75,7 +75,7 @@ When asked to build an agent, follow this structured approach.
 ### Important Constraints
 
 - **Always** communicate in the user's language to ensure clear understanding
-- **Always** use `us.anthropic.claude-sonnet-4-20250514-v1:0`
+- **Always** use `us.anthropic.claude-sonnet-4-6`
 - **Always** verify Strands Agents API usage by checking reference implementations
 - **Do NOT** modify any code outside the `a1_custom/{agent_name}` directory
 - **Do NOT** write code from scratch - refer to existing implementations in `01_code_interpreter` and `02_runtime`


### PR DESCRIPTION
## Summary

Replace deprecated Claude Sonnet 4 with active Claude Sonnet 4.6.

## Changes (5 files)

- `01_code_interpreter/cost_estimator_agent/config.py` — DEFAULT_MODEL
- `03_memory/test_memory.py` — model_id
- `05_evaluation/test_evaluation.py` — modelId
- `09_browser_use/test_browser_use.py` — model_id
- `a1_custom/.kiro/steering/principle.md` — doc reference

## Justification

- `anthropic.claude-sonnet-4-20250514-v1:0` is LEGACY (confirmed via `aws bedrock list-foundation-models` 2026-05-31)
- `anthropic.claude-sonnet-4-6` is ACTIVE (launched Feb 17, 2026)
- Invocation verified: `us.anthropic.claude-sonnet-4-6` works via Converse API without version suffix

## Testing

Verified end-to-end on a live AWS environment (us-east-1) on 2026-05-31. New model ID is a valid, ACTIVE inference profile and every consuming code path works.

**Invocation paths**

- [x] `01_code_interpreter` — Strands `BedrockModel` → ConverseStream ✅
- [x] `03_memory` — boto3 `bedrock-runtime.converse()` ✅
- [x] `09_browser_use` — boto3 `bedrock-runtime.converse()` ✅
- [x] `05_evaluation` — server-side `create_evaluator` (LLM-as-a-judge); evaluator reached `ACTIVE` with the new ID (throwaway resource, cleaned up) ✅

The `05_evaluation` path was the main risk (server-side services sometimes reject short-form inference-profile IDs), so it was validated by registering a temporary evaluator with the new ID, confirming it became `ACTIVE`, then deleting it.

**Workshop steps**

- [x] Step 01 (local) — `test_cost_estimator_agent.py` PASS: agent ran with the new model, called the real `get_pricing` tool, produced a valid EC2 t3.micro estimate.
- [x] Step 02 (live runtime) — deployed via `direct_code_deploy` and invoked on AgentCore Runtime; returned a full tool-calling cost estimate. Confirms the new model works in the deployed runtime, not just locally.

**Notes**

- `02_runtime/deployment/cost_estimator_agent/` is gitignored and regenerated from `01_code_interpreter/cost_estimator_agent` by `prepare_agent.py` on every step-02 run, so it picks up the new model ID automatically — no committed inconsistency.
- No tracked changes exist beyond the 5 model-ID lines in this PR.
