### PR TITLE
fix: enable observability spans (02_runtime) and unblock gateway SAM build (07_gateway)

### DIFF
--- a/02_runtime/deployment/requirements.txt
+++ b/02_runtime/deployment/requirements.txt
@@ -5,3 +5,8 @@ bedrock-agentcore-starter-toolkit>=0.1.1
 strands-agents>=1.0.1
 strands-agents-tools>=0.2.1
 uv
+# ADOT distro activates OpenTelemetry auto-instrumentation so the Strands agent
+# emits application-level spans (model invocations, tool calls) with token counts.
+# Required whenever observability.enabled is true in .bedrock_agentcore.yaml —
+# without it only the platform's outer wrapper span reaches CloudWatch.
+aws-opentelemetry-distro>=0.10.0

--- a/07_gateway/deploy.sh
+++ b/07_gateway/deploy.sh
@@ -12,6 +12,13 @@ else
     echo "Warning: No virtual environment found. Using system Python."
 fi
 
+# Ensure pip is available in the active environment.
+# `uv venv` does not install pip by default, but SAM's PythonPipBuilder needs it
+# to resolve the Lambda function's dependencies during `sam build`. Bootstrap it
+# from the bundled CPython wheel, falling back to uv's pip interface.
+echo "Ensuring pip is available for SAM build..."
+python -m ensurepip --upgrade 2>/dev/null || uv pip install pip
+
 STACK_NAME="AWS-Cost-Estimator-Tool-Markdown-To-Email"
 REGION=$(aws configure get region 2>/dev/null || true)
 if [ $# -lt 1 ]; then


### PR DESCRIPTION
## Summary

Resolves two workshop-blocking issues reported in the troubleshooting guide. Each maps to a single, verified root cause; the actual code change is **2 files, +12 lines**.

| Issue (symptom) | Lab | Root cause | Fix |
|---|---|---|---|
| Only 1 span, 0 tokens, no child spans in GenAI dashboard | `02_runtime` | `observability.enabled: true` but `aws-opentelemetry-distro` (ADOT) missing, so OTEL auto-instrumentation never activates — only the platform wrapper span is emitted | Add `aws-opentelemetry-distro>=0.10.0` to `requirements.txt` |
| `sam build` fails: `PythonPipBuilder:ResolveDependencies - Failed to find a Python runtime containing pip` | `07_gateway` | `uv venv` omits pip by default; `deploy.sh` activates it then runs `sam build`, which requires pip to resolve the Lambda deps | Bootstrap pip via `ensurepip` (fallback `uv pip install pip`) before `sam build` |

## Why these fixes

**02_runtime — ADOT dependency.** Matches the [official AgentCore observability docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html) verbatim (`aws-opentelemetry-distro>=0.10.0`), and aligns `requirements.txt` with what `04_observability/README.md` already prescribes. Without it, the runtime emits only the outer `AgentCore.Runtime.Invoke` span — no model/tool child spans and no token counts.

**07_gateway — pip bootstrap.** SAM's `PythonPipBuilder` requires pip in the build interpreter (confirmed in [aws-lambda-builders#135](https://github.com/aws/aws-lambda-builders/issues/135)). Because pip is a *build-time tool*, not an app dependency, it is installed imperatively into the active venv rather than declared in `pyproject.toml`/`uv.lock`. The bootstrap lives in `deploy.sh` so it runs every deploy (imperative installs are ephemeral under `uv sync`). The Lambda's deps (`boto3`, `markdown`) are pure-Python wheels (`py3-none-any`), so a host pip bootstrap is sufficient and `--use-container` is not required.

## Testing
- `bash -n 07_gateway/deploy.sh` — syntax OK
- Verified a fresh `uv venv` has no pip, and both `ensurepip` and `uv pip install pip` install it into the venv
- Confirmed all `07_gateway/src/requirements.txt` wheels are pure-Python (no C-extensions / OS-specific binaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)