### PR TITLE
fix(03_memory): migrate to namespaceTemplates and align namespace design

### DIFF
--- a/03_memory/README.md
+++ b/03_memory/README.md
@@ -92,8 +92,6 @@ class AgentWithMemory:
                 "userPreferenceMemoryStrategy": {
                     "name": "UserPreferenceExtractor",
                     "description": "Extracts user preferences for AWS architecture decisions",
-                    # {actorId} is a literal template variable — the service resolves it
-                    # per create_event(), isolating each user under their own namespace.
                     "namespaceTemplates": ["/actor/{actorId}/preferences/"]
                 }
             }],
@@ -149,25 +147,6 @@ def estimate(self, architecture_description: str) -> str:
 - **Purpose**: Learn user decision patterns and preferences over time
 - **Note**: Extraction is **asynchronous** ([AWS docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/long-term-saving-and-retrieving-insights.html))
 - **Use Case**: Recommend architectures based on historical choices
-
-#### Namespace: define with `{actorId}`, retrieve with the resolved value
-
-A namespace organizes long-term memories and isolates them per actor. The template is written once and resolved by the service at write time, so the two sides are asymmetric:
-
-| Process | Code | Who resolves `{actorId}` |
-|---------|------|--------------------------|
-| **Define** (`create_memory`) | `namespaceTemplates=["/actor/{actorId}/preferences/"]` | Literal placeholder — the **service** resolves it per `create_event()` |
-| **Retrieve** (`retrieve_memories`) | `namespace=f"/actor/{self.actor_id}/preferences/"` | **You** resolve it; it must match the stored path |
-
-```
-create_memory   "/actor/{actorId}/preferences/"      ← literal template
-create_event    actor_id="user123"
-              → stored at "/actor/user123/preferences/"   ← service resolves
-retrieve        f"/actor/{self.actor_id}/preferences/"
-              → "/actor/user123/preferences/"             ← must match
-```
-
-Because both sides derive from the same `actor_id`, they cannot drift. Use actor-first ordering (`/actor/{actorId}/...`) so each user's data stays isolated and IAM can scope access per user with `namespacePath=/actor/${aws:PrincipalTag/userId}/*`. Do **not** f-string the template at definition time — that bakes one actor in and defeats per-user isolation. See [namespace design patterns](https://aws.amazon.com/blogs/machine-learning/organizing-agents-memory-at-scale-namespace-design-patterns-in-agentcore-memory/) and [specify long-term memory organization](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/specify-long-term-memory-organization.html).
 
 ## Usage Examples
 

--- a/03_memory/README.md
+++ b/03_memory/README.md
@@ -92,7 +92,9 @@ class AgentWithMemory:
                 "userPreferenceMemoryStrategy": {
                     "name": "UserPreferenceExtractor",
                     "description": "Extracts user preferences for AWS architecture decisions",
-                    "namespaces": [f"/preferences/{self.actor_id}"]
+                    # {actorId} is a literal template variable — the service resolves it
+                    # per create_event(), isolating each user under their own namespace.
+                    "namespaceTemplates": ["/actor/{actorId}/preferences/"]
                 }
             }],
             event_expiry_days=7,
@@ -147,6 +149,25 @@ def estimate(self, architecture_description: str) -> str:
 - **Purpose**: Learn user decision patterns and preferences over time
 - **Note**: Extraction is **asynchronous** ([AWS docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/long-term-saving-and-retrieving-insights.html))
 - **Use Case**: Recommend architectures based on historical choices
+
+#### Namespace: define with `{actorId}`, retrieve with the resolved value
+
+A namespace organizes long-term memories and isolates them per actor. The template is written once and resolved by the service at write time, so the two sides are asymmetric:
+
+| Process | Code | Who resolves `{actorId}` |
+|---------|------|--------------------------|
+| **Define** (`create_memory`) | `namespaceTemplates=["/actor/{actorId}/preferences/"]` | Literal placeholder — the **service** resolves it per `create_event()` |
+| **Retrieve** (`retrieve_memories`) | `namespace=f"/actor/{self.actor_id}/preferences/"` | **You** resolve it; it must match the stored path |
+
+```
+create_memory   "/actor/{actorId}/preferences/"      ← literal template
+create_event    actor_id="user123"
+              → stored at "/actor/user123/preferences/"   ← service resolves
+retrieve        f"/actor/{self.actor_id}/preferences/"
+              → "/actor/user123/preferences/"             ← must match
+```
+
+Because both sides derive from the same `actor_id`, they cannot drift. Use actor-first ordering (`/actor/{actorId}/...`) so each user's data stays isolated and IAM can scope access per user with `namespacePath=/actor/${aws:PrincipalTag/userId}/*`. Do **not** f-string the template at definition time — that bakes one actor in and defeats per-user isolation. See [namespace design patterns](https://aws.amazon.com/blogs/machine-learning/organizing-agents-memory-at-scale-namespace-design-patterns-in-agentcore-memory/) and [specify long-term memory organization](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/specify-long-term-memory-organization.html).
 
 ## Usage Examples
 

--- a/03_memory/README_ja.md
+++ b/03_memory/README_ja.md
@@ -86,8 +86,6 @@ class AgentWithMemory:
                 "userPreferenceMemoryStrategy": {
                     "name": "UserPreferenceExtractor",
                     "description": "AWSアーキテクチャ決定のためのユーザー設定を抽出",
-                    # {actorId} はリテラルのテンプレート変数です。サービスが create_event()
-                    # ごとに解決し、各ユーザーを専用のネームスペースに分離します。
                     "namespaceTemplates": ["/actor/{actorId}/preferences/"]
                 }
             }],
@@ -139,25 +137,6 @@ def estimate(self, architecture_description: str) -> str:
 - **目的**: 時間の経過とともにユーザーの決定パターンと設定を学習
 - **実装**: ユーザー設定戦略で`retrieve_memories()`を使用
 - **ユースケース**: 履歴の選択に基づいてアーキテクチャを推奨
-
-#### ネームスペース: 定義は `{actorId}`、取得は解決済みの値で
-
-ネームスペースは長期メモリを整理し、アクターごとに分離します。テンプレートは一度だけ定義し、書き込み時にサービスが解決するため、定義側と取得側は非対称になります。
-
-| プロセス | コード | `{actorId}` を解決するのは |
-|----------|--------|----------------------------|
-| **定義**（`create_memory`） | `namespaceTemplates=["/actor/{actorId}/preferences/"]` | リテラルのプレースホルダー。`create_event()` ごとに**サービス**が解決 |
-| **取得**（`retrieve_memories`） | `namespace=f"/actor/{self.actor_id}/preferences/"` | **呼び出し側**が解決。保存済みのパスと一致させる必要がある |
-
-```
-create_memory   "/actor/{actorId}/preferences/"      ← リテラルのテンプレート
-create_event    actor_id="user123"
-              → "/actor/user123/preferences/" に保存   ← サービスが解決
-retrieve        f"/actor/{self.actor_id}/preferences/"
-              → "/actor/user123/preferences/"          ← 一致が必要
-```
-
-両側とも同じ `actor_id` から導出されるため、ずれることはありません。アクターを先頭に置く順序（`/actor/{actorId}/...`）を使うことで各ユーザーのデータが分離され、IAM は `namespacePath=/actor/${aws:PrincipalTag/userId}/*` でユーザーごとにアクセスを制限できます。定義時にテンプレートを f-string で展開しないでください。1つのアクターが埋め込まれ、ユーザーごとの分離が失われます。詳細は [ネームスペース設計パターン](https://aws.amazon.com/blogs/machine-learning/organizing-agents-memory-at-scale-namespace-design-patterns-in-agentcore-memory/) と [ネームスペースによる長期メモリの整理](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/specify-long-term-memory-organization.html) を参照してください。
 
 ## 使用例
 

--- a/03_memory/README_ja.md
+++ b/03_memory/README_ja.md
@@ -86,7 +86,9 @@ class AgentWithMemory:
                 "userPreferenceMemoryStrategy": {
                     "name": "UserPreferenceExtractor",
                     "description": "AWSアーキテクチャ決定のためのユーザー設定を抽出",
-                    "namespaces": [f"/preferences/{self.actor_id}"]
+                    # {actorId} はリテラルのテンプレート変数です。サービスが create_event()
+                    # ごとに解決し、各ユーザーを専用のネームスペースに分離します。
+                    "namespaceTemplates": ["/actor/{actorId}/preferences/"]
                 }
             }],
             event_expiry_days=7,
@@ -137,6 +139,25 @@ def estimate(self, architecture_description: str) -> str:
 - **目的**: 時間の経過とともにユーザーの決定パターンと設定を学習
 - **実装**: ユーザー設定戦略で`retrieve_memories()`を使用
 - **ユースケース**: 履歴の選択に基づいてアーキテクチャを推奨
+
+#### ネームスペース: 定義は `{actorId}`、取得は解決済みの値で
+
+ネームスペースは長期メモリを整理し、アクターごとに分離します。テンプレートは一度だけ定義し、書き込み時にサービスが解決するため、定義側と取得側は非対称になります。
+
+| プロセス | コード | `{actorId}` を解決するのは |
+|----------|--------|----------------------------|
+| **定義**（`create_memory`） | `namespaceTemplates=["/actor/{actorId}/preferences/"]` | リテラルのプレースホルダー。`create_event()` ごとに**サービス**が解決 |
+| **取得**（`retrieve_memories`） | `namespace=f"/actor/{self.actor_id}/preferences/"` | **呼び出し側**が解決。保存済みのパスと一致させる必要がある |
+
+```
+create_memory   "/actor/{actorId}/preferences/"      ← リテラルのテンプレート
+create_event    actor_id="user123"
+              → "/actor/user123/preferences/" に保存   ← サービスが解決
+retrieve        f"/actor/{self.actor_id}/preferences/"
+              → "/actor/user123/preferences/"          ← 一致が必要
+```
+
+両側とも同じ `actor_id` から導出されるため、ずれることはありません。アクターを先頭に置く順序（`/actor/{actorId}/...`）を使うことで各ユーザーのデータが分離され、IAM は `namespacePath=/actor/${aws:PrincipalTag/userId}/*` でユーザーごとにアクセスを制限できます。定義時にテンプレートを f-string で展開しないでください。1つのアクターが埋め込まれ、ユーザーごとの分離が失われます。詳細は [ネームスペース設計パターン](https://aws.amazon.com/blogs/machine-learning/organizing-agents-memory-at-scale-namespace-design-patterns-in-agentcore-memory/) と [ネームスペースによる長期メモリの整理](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/specify-long-term-memory-organization.html) を参照してください。
 
 ## 使用例
 

--- a/03_memory/test_memory.py
+++ b/03_memory/test_memory.py
@@ -148,13 +148,17 @@ class AgentWithMemory:
             if existing_memory is None:
                 # Create new memory
                 logger.info("Creating new AgentCore Memory...")
+                # Define the long-term memory strategy with a namespace *template*.
+                # {actorId} is a literal placeholder here — the AgentCore service
+                # resolves it to the concrete actor_id passed to create_event(), so a
+                # single memory resource isolates preferences per user.
                 self.memory = self.memory_client.create_memory_and_wait(
                     name=memory_name,
                     strategies=[{
                         "userPreferenceMemoryStrategy": {
                             "name": "UserPreferenceExtractor",
                             "description": "Extracts user preferences for AWS architecture decisions",
-                            "namespaces": [f"/preferences/{self.actor_id}"]
+                            "namespaceTemplates": ["/actor/{actorId}/preferences/"]
                         }
                     }],
                     event_expiry_days=7,  # Minimum allowed value
@@ -343,7 +347,10 @@ class AgentWithMemory:
             # Long-term memory extraction is asynchronous.
             # Poll retrieve_memories() until results appear (or timeout).
             # https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/long-term-saving-and-retrieving-insights.html
-            namespace = f"/preferences/{self.actor_id}"
+            # Resolve the template into the concrete path the service wrote to.
+            # This must equal what "/actor/{actorId}/preferences/" resolved to at
+            # create_event() time — both derive from actor_id, so they stay aligned.
+            namespace = f"/actor/{self.actor_id}/preferences/"
             query = f"User preferences and decision patterns for: {requirements}"
             memories = []
             max_wait, poll_interval = 60, 5


### PR DESCRIPTION
## Summary

Fixes the namespace handling in `03_memory` so it demonstrates the correct, forward-compatible pattern for the three memory processes (define → register → retrieve). Closes #46.

The current code bakes `actor_id` into the namespace on both sides, so it is self-consistent for the single demo actor and retrieves correctly today — but it uses the **deprecated `namespaces` field** and a **hard-coded actor** instead of the service-resolved `{actorId}` template. This PR corrects both.

## Changes

**`test_memory.py`**
- **Define** (`create_memory`): `namespaces: [f"/preferences/{self.actor_id}"]` → `namespaceTemplates: ["/actor/{actorId}/preferences/"]`
  - `{actorId}` is a **literal** template variable; the service resolves it per `create_event()`, so one memory resource isolates preferences per user.
- **Retrieve** (`propose`): `namespace = f"/actor/{self.actor_id}/preferences/"`
  - You resolve the concrete path here; it matches what the template resolved to at write time.

**`README.md` / `README_ja.md`**
- Updated the strategy snippet.
- Added a "define with `{actorId}`, retrieve with the resolved value" section explaining the asymmetry (who resolves the variable, and why not to f-string the template). JA kept in sync.

## Why actor-first (`/actor/{actorId}/...`)

- Single-call per-user retrieval — exactly what `propose()` needs.
- Clean per-user IAM boundary: `namespacePath=/actor/${aws:PrincipalTag/userId}/*`.

Cross-user "survey" retrieval was evaluated only to confirm the rules generalize; it is intentionally out of scope for the workshop and not added to the code.

## Verification

- `ruff check 03_memory/test_memory.py` → **All checks passed!**
- No stale `namespaces` / `/preferences/{self.actor_id}` references remain.
- Store and retrieve paths both derive from `actor_id`, so they cannot drift.

### References
- [Namespace design patterns (actor-scoping, namespace vs namespacePath, IAM)](https://aws.amazon.com/blogs/machine-learning/organizing-agents-memory-at-scale-namespace-design-patterns-in-agentcore-memory/)
- [Specify long-term memory organization with namespaces](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/specify-long-term-memory-organization.html)
- [MemoryStrategy API reference — `namespaces` deprecated, `namespaceTemplates` current](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_MemoryStrategy.html)
- [`retrieve_memory_records` — namespace vs namespacePath](https://docs.aws.amazon.com/boto3/latest/reference/services/bedrock-agentcore/client/retrieve_memory_records.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
