### PR TITLE
feat: add cost_estimator_agent with AgentCore Runtime deployment

### DIFF
--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/README.md
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/README.md
@@ -1,0 +1,239 @@
+# AgentCore Cost Estimator Agent
+
+[English](README.md) / [日本語](README_ja.md)
+
+A secure AWS cost estimation agent deployed on AgentCore Runtime. Combines real-time AWS pricing data via MCP with sandboxed Python execution via AgentCore Code Interpreter to provide accurate cost estimates for system architectures.
+
+## Process Overview
+
+```mermaid
+sequenceDiagram
+    participant User as User Input
+    participant Runtime as AgentCore Runtime
+    participant Agent as Cost Estimator Agent
+    participant MCP as AWS Pricing MCP
+    participant CodeInt as AgentCore Code Interpreter
+
+    User->>Runtime: Architecture Description
+    Runtime->>Agent: invoke(payload, context)
+    Agent->>MCP: Fetch AWS Pricing Data
+    MCP-->>Agent: Current Pricing Info
+    Agent->>CodeInt: Execute Cost Calculations
+    CodeInt-->>Agent: Cost Estimates
+    Agent-->>Runtime: Streaming Response
+    Runtime-->>User: Detailed Cost Breakdown
+```
+
+## Prerequisites
+
+1. **AWS credentials** — With Bedrock access permissions
+2. **Python 3.12+** — Required for async/await support
+3. **Node.js** — Required for CDK (used by `agentcore deploy`)
+4. **AgentCore CLI** — `npm install -g @aws/agentcore@preview`
+5. **uv** — Python package manager
+
+## Directory Structure
+
+```
+CostEstimatorAgent/app/CostEstimatorAgent/
+├── main.py                     # Runtime entrypoint
+├── cost_estimator_agent.py     # Agent as Cost Estimator Agent (AWSCostEstimatorAgent class)
+├── config.py                   # Prompts and model configuration
+├── __init__.py                 # Package initialization
+└── pyproject.toml              # Python dependencies
+```
+
+## How to Use
+
+### Deploy to AWS
+
+```bash
+# 1. Generate scaffold with agentcore create
+cd agents/
+agentcore create \
+    --name MyCostEstimatorAgent \
+    --framework Strands \
+    --model-provider Bedrock \
+    --protocol HTTP \
+    --build CodeZip \
+    --memory none \
+    --skip-git
+
+# 2. Setup agent code and configure policies
+python setup.py --source CostEstimatorAgent --target MyCostEstimatorAgent
+
+# 4. Install dependencies
+cd app/MyCostEstimatorAgent
+uv sync
+
+# 5. Deploy
+cd ../..
+agentcore deploy
+
+# 6. Invoke
+agentcore invoke '{"prompt": "Estimate monthly cost for one EC2 t3.micro running 24/7 in us-west-2"}'
+```
+
+### Local Development
+
+After running `agentcore create` and copying agent code, test locally without deploying:
+
+```bash
+cd MyCostEstimatorAgent/app/MyCostEstimatorAgent
+uv sync
+cd ../..
+agentcore dev
+```
+
+## Key Implementation Patterns
+
+### Facade/Singleton Pattern
+
+```python
+_agent = None
+
+def get_or_create_agent() -> AWSCostEstimatorAgent:
+    """Get or create the cost estimation agent (singleton).
+
+    AWSCostEstimatorAgent is the facade that owns model, tools, and MCP client.
+    Creating it once avoids repeated MCP connection and model initialization.
+    """
+    global _agent
+    if _agent is None:
+        _agent = AWSCostEstimatorAgent(region=REGION)
+    return _agent
+```
+
+### AWSCostEstimatorAgent Initialization (Facade)
+
+```python
+def _initialize(self) -> None:
+    """Initialize all components: Code Interpreter, MCP client, Agent.
+
+    Facade responsibility: builds everything in one place to avoid
+    implicit dependencies on external module-level state.
+    """
+    tools = [self._make_execute_cost_calculation_tool()]
+
+    # MCP Pricing — graceful fallback if unavailable (e.g. Runtime uvx restriction)
+    pricing_tools = self._setup_mcp_pricing()
+    tools.extend(pricing_tools)
+
+    # Code Interpreter session
+    self._setup_code_interpreter()
+
+    # Strands Agent
+    self._agent = Agent(
+        model=self._load_model(),
+        system_prompt=SYSTEM_PROMPT,
+        tools=tools,
+    )
+```
+
+### Secure Code Execution Tool
+
+```python
+@tool
+def execute_cost_calculation(calculation_code: str, description: str = "") -> str:
+    """Execute cost calculations using AgentCore Code Interpreter."""
+    code_interpreter = agent_instance._code_interpreter
+    if not code_interpreter:
+        return "❌ Code Interpreter not initialized"
+
+    try:
+        response = code_interpreter.invoke("executeCode", {
+            "language": "python",
+            "code": calculation_code,
+        })
+
+        results = []
+        for event in response.get("stream", []):
+            if "result" in event:
+                result = event["result"]
+                if "content" in result:
+                    for item in result["content"]:
+                        if item.get("type") == "text":
+                            results.append(item["text"])
+        return "\n".join(results)
+    except Exception as e:
+        return f"❌ Calculation failed: {e}"
+```
+
+### MCP Client with Graceful Fallback
+
+```python
+def _setup_mcp_pricing(self) -> list:
+    """Attempt to start AWS Pricing MCP client. Returns tool list (may be empty)."""
+    try:
+        aws_credentials = self._get_aws_credentials()
+        env_vars = {"FASTMCP_LOG_LEVEL": "ERROR", **aws_credentials}
+
+        uvx_path = shutil.which("uvx")
+        if not uvx_path:
+            from uv._find_uv import find_uv_bin
+            uv_bin = find_uv_bin()
+            uvx_path = os.path.join(os.path.dirname(uv_bin), "uvx")
+
+        uvx_path = self._ensure_executable(uvx_path)
+
+        self._pricing_client = MCPClient(
+            lambda: stdio_client(StdioServerParameters(
+                command=uvx_path,
+                args=["awslabs.aws-pricing-mcp-server@latest"],
+                env=env_vars,
+            ))
+        )
+        self._pricing_client.start()
+        pricing_tools = self._pricing_client.list_tools_sync()
+        logger.info(f"✅ AWS Pricing MCP: {len(pricing_tools)} tools loaded")
+        return pricing_tools
+
+    except Exception as e:
+        logger.warning(f"⚠️ MCP Pricing tools unavailable: {e}")
+        self._pricing_client = None
+        return []
+```
+
+### Streaming with Delta Handling
+
+```python
+@app.entrypoint
+async def invoke(payload, context):
+    """AgentCore Runtime entrypoint with streaming response."""
+    user_input = payload.get("prompt")
+    prompt = COST_ESTIMATION_PROMPT.format(architecture_description=user_input)
+
+    agent = get_or_create_agent()
+
+    try:
+        previous_output = ""
+
+        async for event in agent.stream(prompt):
+            if "data" in event:
+                current_chunk = str(event["data"])
+
+                # Handle delta calculation following Bedrock best practices
+                if current_chunk.startswith(previous_output):
+                    delta_content = current_chunk[len(previous_output):]
+                    if delta_content:
+                        previous_output = current_chunk
+                        yield delta_content
+                else:
+                    previous_output = current_chunk
+                    yield current_chunk
+    except Exception as e:
+        yield f"❌ Streaming cost estimation failed: {e}"
+```
+
+## Security Benefits
+
+- **Sandboxed execution** — Code runs in a secure AgentCore environment
+- **No local code execution** — All calculations performed in AWS sandbox
+- **Resource isolation** — Each calculation runs in an isolated session
+
+## References
+
+- [AgentCore Code Interpreter Developer Guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/code-interpreter.html)
+- [AgentCore Runtime Developer Guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime.html)
+- [AWS Pricing MCP Server](https://github.com/awslabs/aws-pricing-mcp-server)
+- [Strands Agents Documentation](https://github.com/strands-agents/sdk-python)

--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/README_ja.md
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/README_ja.md
@@ -1,0 +1,239 @@
+# AgentCore コスト見積もりエージェント
+
+[English](README.md) / [日本語](README_ja.md)
+
+AgentCore Runtime 上で動作するセキュアな AWS コスト見積もりエージェントです。MCP 経由のリアルタイム AWS 料金データと、AgentCore Code Interpreter によるサンドボックス化された Python 実行を組み合わせて、システムアーキテクチャの正確なコスト見積もりを提供します。
+
+## プロセス概要
+
+```mermaid
+sequenceDiagram
+    participant User as ユーザー入力
+    participant Runtime as AgentCore Runtime
+    participant Agent as コスト見積もりエージェント
+    participant MCP as AWS 料金 MCP
+    participant CodeInt as AgentCore Code Interpreter
+
+    User->>Runtime: アーキテクチャの説明
+    Runtime->>Agent: invoke(payload, context)
+    Agent->>MCP: AWS料金データを取得
+    MCP-->>Agent: 現在の料金情報
+    Agent->>CodeInt: コスト計算を実行
+    CodeInt-->>Agent: コスト見積もり
+    Agent-->>Runtime: ストリーミングレスポンス
+    Runtime-->>User: 詳細なコスト内訳
+```
+
+## 前提条件
+
+1. **AWS 認証情報** — Bedrock のアクセス権限付き
+2. **Python 3.12+** — async/await サポートに必要
+3. **Node.js** — CDK に必要（`agentcore deploy` で使用）
+4. **AgentCore CLI** — `npm install -g @aws/agentcore@preview`
+5. **uv** — Python パッケージマネージャー
+
+## ディレクトリ構成
+
+```
+CostEstimatorAgent/app/CostEstimatorAgent/
+├── main.py                     # Runtime エントリポイント
+├── cost_estimator_agent.py     # コスト見積もりエージェント (AWSCostEstimatorAgent クラス)
+├── config.py                   # プロンプトとモデル設定
+├── __init__.py                 # パッケージ初期化
+└── pyproject.toml              # Python 依存関係
+```
+
+## 使用方法
+
+### AWS へデプロイ
+
+```bash
+# 1. agentcore create で雛形生成
+cd agents/
+agentcore create \
+    --name MyCostEstimatorAgent \
+    --framework Strands \
+    --model-provider Bedrock \
+    --protocol HTTP \
+    --build CodeZip \
+    --memory none \
+    --skip-git
+
+# 2. エージェントコードのセットアップとポリシー設定
+python setup.py --source CostEstimatorAgent --target MyCostEstimatorAgent
+
+# 4. 依存関係をインストール
+cd app/MyCostEstimatorAgent
+uv sync
+
+# 5. デプロイ
+cd ../..
+agentcore deploy
+
+# 6. 呼び出し
+agentcore invoke '{"prompt": "us-west-2 で EC2 t3.micro を1台24時間365日稼働した場合の月額コストを見積もってください"}'
+```
+
+### ローカル開発
+
+`agentcore create` とエージェントコードのコピー後、デプロイせずにローカルで動作確認する場合：
+
+```bash
+cd MyCostEstimatorAgent/app/MyCostEstimatorAgent
+uv sync
+cd ../..
+agentcore dev
+```
+
+## 主要な実装パターン
+
+### Facade/Singleton パターン
+
+```python
+_agent = None
+
+def get_or_create_agent() -> AWSCostEstimatorAgent:
+    """Get or create the cost estimation agent (singleton).
+
+    AWSCostEstimatorAgent is the facade that owns model, tools, and MCP client.
+    Creating it once avoids repeated MCP connection and model initialization.
+    """
+    global _agent
+    if _agent is None:
+        _agent = AWSCostEstimatorAgent(region=REGION)
+    return _agent
+```
+
+### AWSCostEstimatorAgent 初期化（facade）
+
+```python
+def _initialize(self) -> None:
+    """Initialize all components: Code Interpreter, MCP client, Agent.
+
+    Facade responsibility: builds everything in one place to avoid
+    implicit dependencies on external module-level state.
+    """
+    tools = [self._make_execute_cost_calculation_tool()]
+
+    # MCP Pricing — graceful fallback if unavailable (e.g. Runtime uvx restriction)
+    pricing_tools = self._setup_mcp_pricing()
+    tools.extend(pricing_tools)
+
+    # Code Interpreter session
+    self._setup_code_interpreter()
+
+    # Strands Agent
+    self._agent = Agent(
+        model=self._load_model(),
+        system_prompt=SYSTEM_PROMPT,
+        tools=tools,
+    )
+```
+
+### セキュアなコード実行ツール
+
+```python
+@tool
+def execute_cost_calculation(calculation_code: str, description: str = "") -> str:
+    """Execute cost calculations using AgentCore Code Interpreter."""
+    code_interpreter = agent_instance._code_interpreter
+    if not code_interpreter:
+        return "❌ Code Interpreter not initialized"
+
+    try:
+        response = code_interpreter.invoke("executeCode", {
+            "language": "python",
+            "code": calculation_code,
+        })
+
+        results = []
+        for event in response.get("stream", []):
+            if "result" in event:
+                result = event["result"]
+                if "content" in result:
+                    for item in result["content"]:
+                        if item.get("type") == "text":
+                            results.append(item["text"])
+        return "\n".join(results)
+    except Exception as e:
+        return f"❌ Calculation failed: {e}"
+```
+
+### MCP クライアントのグレースフルフォールバック
+
+```python
+def _setup_mcp_pricing(self) -> list:
+    """Attempt to start AWS Pricing MCP client. Returns tool list (may be empty)."""
+    try:
+        aws_credentials = self._get_aws_credentials()
+        env_vars = {"FASTMCP_LOG_LEVEL": "ERROR", **aws_credentials}
+
+        uvx_path = shutil.which("uvx")
+        if not uvx_path:
+            from uv._find_uv import find_uv_bin
+            uv_bin = find_uv_bin()
+            uvx_path = os.path.join(os.path.dirname(uv_bin), "uvx")
+
+        uvx_path = self._ensure_executable(uvx_path)
+
+        self._pricing_client = MCPClient(
+            lambda: stdio_client(StdioServerParameters(
+                command=uvx_path,
+                args=["awslabs.aws-pricing-mcp-server@latest"],
+                env=env_vars,
+            ))
+        )
+        self._pricing_client.start()
+        pricing_tools = self._pricing_client.list_tools_sync()
+        logger.info(f"✅ AWS Pricing MCP: {len(pricing_tools)} tools loaded")
+        return pricing_tools
+
+    except Exception as e:
+        logger.warning(f"⚠️ MCP Pricing tools unavailable: {e}")
+        self._pricing_client = None
+        return []
+```
+
+### デルタハンドリングを使用したストリーミング
+
+```python
+@app.entrypoint
+async def invoke(payload, context):
+    """AgentCore Runtime entrypoint with streaming response."""
+    user_input = payload.get("prompt")
+    prompt = COST_ESTIMATION_PROMPT.format(architecture_description=user_input)
+
+    agent = get_or_create_agent()
+
+    try:
+        previous_output = ""
+
+        async for event in agent.stream(prompt):
+            if "data" in event:
+                current_chunk = str(event["data"])
+
+                # Handle delta calculation following Bedrock best practices
+                if current_chunk.startswith(previous_output):
+                    delta_content = current_chunk[len(previous_output):]
+                    if delta_content:
+                        previous_output = current_chunk
+                        yield delta_content
+                else:
+                    previous_output = current_chunk
+                    yield current_chunk
+    except Exception as e:
+        yield f"❌ Streaming cost estimation failed: {e}"
+```
+
+## セキュリティの利点
+
+- **サンドボックス実行** - コードはセキュアな AgentCore 環境で実行
+- **ローカルコード実行なし** - すべての計算は AWS サンドボックスで実行
+- **リソース分離** - 各計算は分離されたセッションで実行
+
+## 参考資料
+
+- [AgentCore Code Interpreter Developer Guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/code-interpreter.html)
+- [AgentCore Runtime Developer Guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime.html)
+- [AWS Pricing MCP Server](https://github.com/awslabs/aws-pricing-mcp-server)
+- [Strands Agents Documentation](https://github.com/strands-agents/sdk-python)

--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/__init__.py
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/__init__.py
@@ -1,0 +1,3 @@
+from cost_estimator_agent import AWSCostEstimatorAgent
+
+__all__ = ["AWSCostEstimatorAgent"]

--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/config.py
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/config.py
@@ -1,0 +1,61 @@
+"""
+Configuration for AWS Cost Estimation Agent
+
+This module contains all prompts and configuration values,
+separated from the main logic to maintain clean code structure
+and pass linting tools.
+"""
+
+# System prompt for the AWS Cost Estimation Agent
+SYSTEM_PROMPT = """You are an AWS Cost Estimation Expert Agent.
+
+Your role is to analyze system architecture descriptions and provide accurate AWS cost estimates.
+
+PRINCIPLE:
+- Speed is essential. Because we can adjust the architecture later, focus on providing a quick estimate first.
+- Talk inquirer's language. If they ask in English, respond in English. If they ask in Japanese, respond in Japanese.
+- Use tools appropriately.
+
+PROCESS:
+0. If user specified [quick] option, skip using tools and return a quick estimate.
+1. Parse the architecture description to identify AWS services and regions.
+2. Call get_pricing for each service with output_options and filters (see below).
+   - The response shows available attributes — use them to understand the data.
+   - If the service code is unknown, use get_pricing_service_codes with a regex
+     filter (e.g., filter="EC2") to discover it. Never call it without a filter.
+3. Calculate costs using the secure Code Interpreter WITH the retrieved pricing data.
+4. Provide cost estimation with unit prices and monthly totals.
+
+get_pricing USAGE:
+- ALWAYS pass output_options to keep responses compact:
+    "output_options": {
+        "pricing_terms": ["OnDemand"],
+        "exclude_free_products": true
+    }
+- Use max_results: 5 as a safety net to avoid oversized responses.
+- Use filters to narrow results (e.g., instanceType, location, operatingSystem).
+- If you need to discover valid filter fields or values for an unfamiliar service,
+  use get_pricing_service_attributes and get_pricing_attribute_values.
+
+NEVER DO:
+- Call get_pricing without output_options — raw responses are too large.
+- Search for extra pricing data for services not in the architecture.
+- Try to call MCP tools from within execute_cost_calculation (they are not available in Code Interpreter).
+
+OUTPUT FORMAT:
+- Architecture description
+- Table of Service list with unit prices and monthly totals
+- Discussion points
+"""
+
+# Cost estimation prompt template
+COST_ESTIMATION_PROMPT = """
+Please analyze this architecture and provide an AWS cost estimate:
+{architecture_description}
+"""
+
+# Model configuration
+DEFAULT_MODEL = "us.anthropic.claude-sonnet-4-6"
+
+# Logging configuration
+LOG_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"

--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/cost_estimator_agent.py
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/cost_estimator_agent.py
@@ -1,0 +1,249 @@
+"""
+AWS Cost Estimation Agent using Amazon Bedrock AgentCore Code Interpreter
+
+Facade class that encapsulates:
+- Model creation (BedrockModel with adaptive retry)
+- MCP Pricing client (stdio via uvx, graceful fallback)
+- Code Interpreter tool (secure sandbox execution)
+- Strands Agent orchestration
+"""
+
+import logging
+import os
+import shutil
+import boto3
+from typing import AsyncGenerator
+from strands import Agent, tool
+from strands.models import BedrockModel
+from strands.tools.mcp import MCPClient
+from strands.handlers.callback_handler import null_callback_handler
+from botocore.config import Config
+from mcp import stdio_client, StdioServerParameters
+from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
+from config import SYSTEM_PROMPT, DEFAULT_MODEL
+
+logger = logging.getLogger(__name__)
+
+
+class AWSCostEstimatorAgent:
+    """AWS Cost Estimation Agent — Facade/Singleton.
+
+    Owns all resources (model, tools, MCP client, Code Interpreter) and
+    exposes a single streaming interface. Constructed once and reused
+    across invocations for memory efficiency.
+    """
+
+    def __init__(self, region: str = ""):
+        self.region = region or (
+            os.environ.get('AWS_DEFAULT_REGION')
+            or os.environ.get('AWS_REGION')
+            or boto3.Session().region_name
+        )
+        self._code_interpreter = None
+        self._pricing_client = None
+        self._agent = None
+
+        self._initialize()
+
+    def __del__(self):
+        """Release resources on garbage collection."""
+        self.cleanup()
+
+    def _initialize(self) -> None:
+        """Initialize all components: pricing tools, Code Interpreter, Agent.
+
+        Facade responsibility: builds everything in one place to avoid
+        implicit dependencies on external module-level state.
+        """
+        # 1. Pricing tools (MCP)
+        pricing_tools = self._prepare_pricing_tools()
+
+        # 2. Code Interpreter for secure calculations
+        self._prepare_code_interpreter()
+
+        # 3. Build agent with all tools
+        tools = pricing_tools + [self._prepare_cost_calculation_tool()]
+        self._agent = Agent(
+            model=self._load_model(),
+            system_prompt=SYSTEM_PROMPT,
+            tools=tools,
+        )
+
+    def _load_model(self) -> BedrockModel:
+        """Create BedrockModel with extended timeouts for cost estimation."""
+        return BedrockModel(
+            boto_client_config=Config(
+                read_timeout=900,
+                connect_timeout=900,
+                retries=dict(max_attempts=3, mode="adaptive"),
+            ),
+            model_id=DEFAULT_MODEL,
+        )
+
+    def _prepare_pricing_tools(self) -> list:
+        """Prepare AWS Pricing MCP tools. Returns tool list (may be empty)."""
+        try:
+            aws_credentials = self._get_aws_credentials()
+            env_vars = {"FASTMCP_LOG_LEVEL": "ERROR", **aws_credentials}
+
+            uvx_path = shutil.which("uvx")
+            if not uvx_path:
+                from uv._find_uv import find_uv_bin
+                uv_bin = find_uv_bin()
+                uvx_path = os.path.join(os.path.dirname(uv_bin), "uvx")
+
+            uvx_path = self._ensure_executable(uvx_path)
+
+            self._pricing_client = MCPClient(
+                lambda: stdio_client(StdioServerParameters(
+                    command=uvx_path,
+                    args=["awslabs.aws-pricing-mcp-server@latest"],
+                    env=env_vars,
+                ))
+            )
+            self._pricing_client.start()
+            pricing_tools = self._pricing_client.list_tools_sync()
+            logger.info(f"✅ AWS Pricing MCP: {len(pricing_tools)} tools loaded")
+            return pricing_tools
+
+        except Exception as e:
+            logger.warning(f"⚠️ MCP Pricing tools unavailable: {e}")
+            self._pricing_client = None
+            return []
+
+    def _prepare_code_interpreter(self) -> None:
+        """Start AgentCore Code Interpreter session."""
+        try:
+            self._code_interpreter = CodeInterpreter(self.region)
+            self._code_interpreter.start()
+            logger.info("✅ Code Interpreter session started")
+        except Exception as e:
+            logger.error(f"❌ Failed to setup Code Interpreter: {e}")
+
+    def _prepare_cost_calculation_tool(self):
+        """Prepare the Code Interpreter tool bound to this instance."""
+        agent_instance = self
+
+        @tool
+        def execute_cost_calculation(calculation_code: str, description: str = "") -> str:
+            """Execute cost calculations using AgentCore Code Interpreter.
+
+            Args:
+                calculation_code: Python code for cost calculations
+                description: Description of what the calculation does
+
+            Returns:
+                Calculation results as string
+            """
+            code_interpreter = agent_instance._code_interpreter
+            if not code_interpreter:
+                return "❌ Code Interpreter not initialized"
+
+            try:
+                logger.info(f"🧮 Executing calculation: {description}")
+                response = code_interpreter.invoke("executeCode", {
+                    "language": "python",
+                    "code": calculation_code,
+                })
+
+                results = []
+                for event in response.get("stream", []):
+                    if "result" in event:
+                        result = event["result"]
+                        if "content" in result:
+                            for item in result["content"]:
+                                if item.get("type") == "text":
+                                    results.append(item["text"])
+                return "\n".join(results)
+
+            except Exception as e:
+                logger.error(f"❌ Calculation failed: {e}")
+                return f"❌ Calculation failed: {e}"
+
+        return execute_cost_calculation
+
+    def _ensure_executable(self, uvx_path: str) -> str:
+        """Ensure uvx (and uv) have execute permission.
+
+        On AgentCore Runtime (CodeZip), /var/task is read-only so chmod fails.
+        In that case, copy both uv and uvx to /tmp (if not already there) and
+        grant execute permission.
+        """
+        import stat
+        import tempfile
+
+        if os.access(uvx_path, os.X_OK):
+            return uvx_path
+
+        try:
+            os.chmod(uvx_path, os.stat(uvx_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            return uvx_path
+        except PermissionError:
+            pass
+
+        tmp_dir = tempfile.gettempdir()
+        tmp_uvx = os.path.join(tmp_dir, "uvx")
+
+        if os.path.exists(tmp_uvx) and os.access(tmp_uvx, os.X_OK):
+            logger.info(f"✅ Reusing executable uvx from {tmp_dir}")
+            return tmp_uvx
+
+        bin_dir = os.path.dirname(uvx_path)
+        for binary in ["uvx", "uv"]:
+            src = os.path.join(bin_dir, binary)
+            dst = os.path.join(tmp_dir, binary)
+            if os.path.exists(src):
+                shutil.copy2(src, dst)
+                os.chmod(dst, 0o755)
+
+        logger.info(f"✅ Copied uv + uvx to {tmp_dir} with exec permission")
+        return tmp_uvx
+
+    def _get_aws_credentials(self) -> dict:
+        """Get current AWS credentials including session token."""
+        try:
+            session = boto3.Session()
+            credentials = session.get_credentials()
+            if credentials is None:
+                raise Exception("No AWS credentials found")
+
+            frozen_creds = credentials.get_frozen_credentials()
+            creds = {
+                "AWS_ACCESS_KEY_ID": frozen_creds.access_key,
+                "AWS_SECRET_ACCESS_KEY": frozen_creds.secret_key,
+                "AWS_REGION": self.region,
+            }
+            if frozen_creds.token:
+                creds["AWS_SESSION_TOKEN"] = frozen_creds.token
+            return creds
+
+        except Exception as e:
+            logger.error(f"❌ Failed to get AWS credentials: {e}")
+            return {}
+
+    async def stream(self, prompt: str) -> AsyncGenerator[dict, None]:
+        """Stream agent response for a given prompt.
+
+        Yields:
+            dict with "data" key containing text chunks
+        """
+        async for event in self._agent.stream_async(
+            prompt, callback_handler=null_callback_handler
+        ):
+            yield event
+
+    def cleanup(self) -> None:
+        """Release resources."""
+        if self._code_interpreter:
+            try:
+                self._code_interpreter.stop()
+            except Exception:
+                pass
+            self._code_interpreter = None
+
+        if self._pricing_client:
+            try:
+                self._pricing_client.stop()
+            except Exception:
+                pass
+            self._pricing_client = None

--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/iam_policies/code-interpreter-policy.json
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/iam_policies/code-interpreter-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CodeInterpreterAccess",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateCodeInterpreter",
+        "bedrock-agentcore:StartCodeInterpreterSession",
+        "bedrock-agentcore:InvokeCodeInterpreter",
+        "bedrock-agentcore:StopCodeInterpreterSession",
+        "bedrock-agentcore:DeleteCodeInterpreter",
+        "bedrock-agentcore:ListCodeInterpreters",
+        "bedrock-agentcore:GetCodeInterpreter",
+        "bedrock-agentcore:GetCodeInterpreterSession",
+        "bedrock-agentcore:ListCodeInterpreterSessions"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:*:*:*"
+    }
+  ]
+}

--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/iam_policies/pricing-api-policy.json
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/iam_policies/pricing-api-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PricingAPIAccess",
+      "Effect": "Allow",
+      "Action": [
+        "pricing:GetProducts",
+        "pricing:DescribeServices",
+        "pricing:GetAttributeValues",
+        "pricing:GetPriceListFileUrl",
+        "pricing:ListPriceLists"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/main.py
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/main.py
@@ -1,0 +1,74 @@
+"""
+AgentCore Runtime Entrypoint for Cost Estimator Agent
+
+Follows the AgentCore CLI scaffold pattern:
+- get_or_create_agent() returns AWSCostEstimatorAgent singleton
+- AWSCostEstimatorAgent encapsulates all tool/model/MCP construction (facade)
+- @app.entrypoint handles streaming with delta deduplication
+"""
+
+import os
+import traceback
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from cost_estimator_agent import AWSCostEstimatorAgent
+from config import COST_ESTIMATION_PROMPT
+
+app = BedrockAgentCoreApp()
+log = app.logger
+
+# --- Constants ---
+REGION = os.environ.get('AWS_DEFAULT_REGION') or os.environ.get('AWS_REGION', 'us-west-2')
+
+# --- Singleton ---
+_agent = None
+
+
+def get_or_create_agent() -> AWSCostEstimatorAgent:
+    """Get or create the cost estimation agent (singleton).
+
+    AWSCostEstimatorAgent is the facade that owns model, tools, and MCP client.
+    Creating it once avoids repeated MCP connection and model initialization.
+    """
+    global _agent
+    if _agent is None:
+        _agent = AWSCostEstimatorAgent(region=REGION)
+    return _agent
+
+
+@app.entrypoint
+async def invoke(payload, context):
+    """AgentCore Runtime entrypoint with streaming response.
+
+    Implements delta-based streaming following Amazon Bedrock best practices.
+    """
+    log.info("Invoking Cost Estimator Agent...")
+
+    user_input = payload.get("prompt")
+    prompt = COST_ESTIMATION_PROMPT.format(architecture_description=user_input)
+
+    agent = get_or_create_agent()
+
+    try:
+        previous_output = ""
+
+        async for event in agent.stream(prompt):
+            if "data" in event:
+                current_chunk = str(event["data"])
+
+                # Handle delta calculation following Bedrock best practices
+                if current_chunk.startswith(previous_output):
+                    delta_content = current_chunk[len(previous_output):]
+                    if delta_content:
+                        previous_output = current_chunk
+                        yield delta_content
+                else:
+                    previous_output = current_chunk
+                    yield current_chunk
+
+    except Exception as e:
+        log.error(f"❌ Streaming cost estimation failed: {e}")
+        yield f"❌ Streaming cost estimation failed: {e}\n\nStacktrace:\n{traceback.format_exc()}"
+
+
+if __name__ == "__main__":
+    app.run()

--- a/agents/CostEstimatorAgent/app/CostEstimatorAgent/pyproject.toml
+++ b/agents/CostEstimatorAgent/app/CostEstimatorAgent/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cost-estimator-agent"
+version = "0.1.0"
+description = "AWS Cost Estimation Agent using Amazon Bedrock AgentCore"
+requires-python = ">=3.12"
+dependencies = [
+    "aws-opentelemetry-distro",
+    "bedrock-agentcore>=1.0.3",
+    "boto3>=1.39.9",
+    "strands-agents>=1.13.0",
+    "strands-agents-tools>=0.2.1",
+    "uv",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/agents/setup.py
+++ b/agents/setup.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Setup script for AgentCore agent deployment.
+
+Copies agent source code into an agentcore create scaffold and configures
+additionalPolicies in agentcore.json. Cross-platform (no jq/cp dependency).
+
+Usage:
+    python setup.py --source CostEstimatorAgent --target MyCostEstimatorAgent
+"""
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+
+def copy_agent_code(source_dir: Path, target_dir: Path) -> None:
+    """Copy agent source code (excluding READMEs) into the target app directory."""
+    # Copy Python files and pyproject.toml
+    for file in source_dir.glob("*.py"):
+        shutil.copy2(file, target_dir / file.name)
+    
+    pyproject = source_dir / "pyproject.toml"
+    if pyproject.exists():
+        shutil.copy2(pyproject, target_dir / "pyproject.toml")
+
+    # Copy iam_policies directory
+    iam_policies_src = source_dir / "iam_policies"
+    if iam_policies_src.exists():
+        iam_policies_dst = target_dir / "iam_policies"
+        if iam_policies_dst.exists():
+            shutil.rmtree(iam_policies_dst)
+        shutil.copytree(iam_policies_src, iam_policies_dst)
+
+
+def configure_additional_policies(agentcore_json_path: Path, policies: list[str]) -> None:
+    """Add additionalPolicies to runtimes[0] in agentcore.json."""
+    with open(agentcore_json_path, "r") as f:
+        config = json.load(f)
+
+    if "runtimes" in config and len(config["runtimes"]) > 0:
+        config["runtimes"][0]["additionalPolicies"] = policies
+
+    with open(agentcore_json_path, "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Setup agent code in agentcore scaffold")
+    parser.add_argument("--source", required=True, help="Source agent directory name (e.g. CostEstimatorAgent)")
+    parser.add_argument("--target", required=True, help="Target scaffold directory name (e.g. MyCostEstimatorAgent)")
+    args = parser.parse_args()
+
+    agents_dir = Path(__file__).parent
+    source_dir = agents_dir / args.source / "app" / args.source
+    target_dir = agents_dir / args.target / "app" / args.target
+    agentcore_json = agents_dir / args.target / "agentcore" / "agentcore.json"
+
+    # Validate paths
+    if not source_dir.exists():
+        print(f"❌ Source directory not found: {source_dir}")
+        return 1
+    if not target_dir.exists():
+        print(f"❌ Target directory not found: {target_dir}")
+        print(f"   Did you run 'agentcore create --name {args.target}' first?")
+        return 1
+    if not agentcore_json.exists():
+        print(f"❌ agentcore.json not found: {agentcore_json}")
+        return 1
+
+    # 1. Copy agent code
+    print(f"📁 Copying agent code: {source_dir.name} → {target_dir.name}")
+    copy_agent_code(source_dir, target_dir)
+
+    # 2. Configure additionalPolicies
+    iam_policies_dir = target_dir / "iam_policies"
+    if iam_policies_dir.exists():
+        policies = [f"iam_policies/{p.name}" for p in sorted(iam_policies_dir.glob("*.json"))]
+        print(f"🔧 Configuring additionalPolicies: {policies}")
+        configure_additional_policies(agentcore_json, policies)
+
+    print("✅ Setup complete!")
+    print(f"\nNext steps:")
+    print(f"  cd {args.target}/app/{args.target}")
+    print(f"  uv sync")
+    print(f"  cd ../..")
+    print(f"  agentcore deploy")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Add CostEstimatorAgent to `agents/` directory

### Summary

Adds `agents/CostEstimatorAgent/app/CostEstimatorAgent/` — the agent code for the AWS cost estimation agent deployed on AgentCore Runtime. This agent estimates AWS costs from architecture descriptions using MCP Pricing Server for live pricing data and AgentCore Code Interpreter for secure calculations.

Repository holds only the `app/` code and a cross-platform `setup.py`. Workshop participants run `agentcore create` to generate the scaffold, then run `setup.py` to copy agent code and configure IAM policies.

### Changes

- `agents/CostEstimatorAgent/app/CostEstimatorAgent/` — Python agent code
  - `main.py` — Runtime entrypoint with singleton + streaming
  - `cost_estimator_agent.py` — `AWSCostEstimatorAgent` class (facade)
  - `config.py` — Prompts and model configuration
  - `__init__.py` — Package re-export
  - `pyproject.toml` — Dependencies (hatchling build)
  - `iam_policies/` — IAM policies for Code Interpreter and Pricing API access
- `agents/setup.py` — Cross-platform setup script (replaces cp + jq, reusable across labs)
- `agents/CostEstimatorAgent/app/CostEstimatorAgent/README.md` / `README_ja.md` — Usage and deployment guide (EN/JA)

### Key Design Decisions

1. **Facade/Singleton pattern** — `AWSCostEstimatorAgent` encapsulates all tool/model/MCP construction; `get_or_create_agent()` holds it as singleton
2. **No `agentcore/` or `cdk/` in repository** — Generated by `agentcore create` at workshop time; only `app/` code is stored
3. **MCP Pricing on Runtime** — `/var/task/bin/uvx` lacks execute permission on CodeZip Runtime; agent copies uv + uvx to `/tmp` on first invocation, then reuses on subsequent calls
4. **additionalPolicies** — Code Interpreter and Pricing API require IAM permissions not included in default CDK-generated role; provided via `iam_policies/*.json`
5. **Delta-based streaming** — Handles overlapping chunks from `stream_async()` following Bedrock best practices
6. **Cross-platform setup.py** — Replaces shell commands (cp, jq) for Windows compatibility; reusable across labs

### Tested

- `agentcore deploy` — successful deployment to us-west-2
- `agentcore invoke` — streaming response with MCP Pricing + Code Interpreter on Runtime
- `agentcore dev` — local development with full tools
- `agentcore logs` — confirmed MCP Pricing (9 tools loaded), Code Interpreter session, and InvokeCodeInterpreter all succeed on Runtime