### PR TITLE
fix: move ruff out of runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,14 @@ dependencies = [
     "bedrock-agentcore-starter-toolkit>=0.1.2",
     "boto3>=1.39.9",
     "playwright>=1.58.0",
-    "ruff>=0.12.4",
     "strands-agents>=1.0.1",
     "strands-agents-evals>=0.1.6",
     "strands-agents-tools>=0.2.1",
+]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.12.4",
 ]
 
 [tool.pyright]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -1934,10 +1934,14 @@ dependencies = [
     { name = "bedrock-agentcore-starter-toolkit" },
     { name = "boto3" },
     { name = "playwright" },
-    { name = "ruff" },
     { name = "strands-agents" },
     { name = "strands-agents-evals" },
     { name = "strands-agents-tools" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1946,11 +1950,13 @@ requires-dist = [
     { name = "bedrock-agentcore-starter-toolkit", specifier = ">=0.1.2" },
     { name = "boto3", specifier = ">=1.39.9" },
     { name = "playwright", specifier = ">=1.58.0" },
-    { name = "ruff", specifier = ">=0.12.4" },
     { name = "strands-agents", specifier = ">=1.0.1" },
     { name = "strands-agents-evals", specifier = ">=0.1.6" },
     { name = "strands-agents-tools", specifier = ">=0.2.1" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.12.4" }]
 
 [[package]]
 name = "shellingham"


### PR DESCRIPTION
## Problem

`ruff` is declared in `[project].dependencies`, which makes a linter and formatter a runtime dependency of this sample. Anyone following the tutorial installs it whether or not they ever lint.

## What changed

`ruff` moves out of the runtime list into a `[dependency-groups]` table, plus the regenerated `uv.lock`. No source changes.

```diff
-    "ruff>=0.12.4",
     "strands-agents>=1.0.1",
     "strands-agents-evals>=0.1.6",
     "strands-agents-tools>=0.2.1",
 ]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.12.4",
+]
```

## Why a new table, and why this one

This project had **no** dev dependency group and no `[project.optional-dependencies]`, so `ruff` could not simply be deleted — that would leave contributors with no declared way to install the linter the repo expects them to use. It had to move somewhere new.

I chose PEP 735 `[dependency-groups]` on two grounds rather than preference:

1. It is the standard Python mechanism for dependencies that are not part of the distribution.
2. This repo already locks with **uv**, and `uv sync` installs dev groups by default — so contributors get `ruff` with no extra flag, exactly as they do today.

If you would rather have `[project.optional-dependencies].dev`, say so and I will switch it.

## Verification

```
$ uv pip compile pyproject.toml
before: 102 packages   (ruff present)
after:  101 packages
```

`uv lock` regenerated successfully.

**What I could not verify:** this repo has no test directory, so there is no suite to run. The evidence here is the dependency resolution above; the change touches no source code, and `ruff` remains installable via `uv sync`.

## Scope

No issue behind this — found by reading the dependency list rather than from a report. CONTRIBUTING asks for an issue first on *significant* work; this is a one-line move, but happy to open one if you'd prefer.

I confirm the licensing of this contribution: you can use, modify, copy, and redistribute it under the terms of your choice.
